### PR TITLE
Explicitly state the bootstrap command

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -169,7 +169,7 @@ function bootstrapSubstrate {
 }
 
 if ! checkWritability; then
-	echo "$THEOSDIR is not writable. Please run $ARGV0 $@ manually, with privileges." 1>&2
+	echo "$THEOSDIR is not writable. Please run \`$ARGV0 $@\` manually, with privileges." 1>&2
 	exit 1
 fi
 


### PR DESCRIPTION
@saurik just tripped up on this at JailbreakCon. He read:

```
/opt/theos is not writable. Please run ./bin/bootstrap.sh substrate manually, with privileges.
```

and ran `./bin/bootstrap.sh`, without the substrate argument. This fixes that:

```
/opt/theos is not writable. Please run `./bin/bootstrap.sh substrate` manually, with privileges.
```
