### PR TITLE
Add option to disable respringing when installing a tweak

### DIFF
--- a/makefiles/master/tweak.mk
+++ b/makefiles/master/tweak.mk
@@ -12,7 +12,7 @@ internal-all:: $(TWEAK_NAME:=.all.tweak.variables);
 internal-stage:: $(TWEAK_NAME:=.stage.tweak.variables);
 
 internal-after-install::
-ifeq ($(DISABLE_RESPRING_ON_INSTALL),)
+ifeq ($(DISABLE_RESPRING),)
 	install.exec "killall -9 SpringBoard"
 endif
 


### PR DESCRIPTION
Just set `DISABLE_RESPRING = 1` in your Makefile.

This is useful to me, as I have several tweaks that targets only specific Apps from the AppStore, which I kill with `preinst` and therefore there is no reason to respring.
