### PR TITLE
Add %property (logo?).

### DIFF
--- a/bin/lib/Logos/Class.pm
+++ b/bin/lib/Logos/Class.pm
@@ -15,6 +15,8 @@ sub new {
 	$self->{REQUIRED} = 0;
 	$self->{METHODS} = [];
 	$self->{NUM_METHODS} = 0;
+    $self->{PROPERTIES} = [];
+    $self->{NUM_PROPERTIES} = 0;
 	$self->{GROUP} = undef;
 	bless($self, $class);
 	return $self;
@@ -89,6 +91,11 @@ sub methods {
 	return $self->{METHODS};
 }
 
+sub properties {
+	my $self = shift;
+	return $self->{PROPERTIES};
+}
+
 sub initRequired {
 	my $self = shift;
 	return $self->required || scalar @{$self->{METHODS}} > 0;
@@ -103,6 +110,13 @@ sub addMethod {
 	my $hook = shift;
 	push(@{$self->{METHODS}}, $hook);
 	$self->{NUM_METHODS}++;
+}
+
+sub addProperty {
+    my $self = shift;
+    my $property = shift;
+    push(@{$self->{PROPERTIES}}, $property);
+    $self->{NUM_PROPERTIES}++;
 }
 
 1;

--- a/bin/lib/Logos/Generator/Base/Class.pm
+++ b/bin/lib/Logos/Generator/Base/Class.pm
@@ -46,6 +46,9 @@ sub initializers {
 	for(@{$class->methods}) {
 		$return .= Logos::Generator::for($_)->initializers;
 	}
+    for(@{$class->properties}) {
+        $return .= Logos::Generator::for($_)->initializers;
+    }
 	return $return;
 }
 

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -139,23 +139,6 @@ sub getters_setters {
     $build .= $build . "static char " . $key . ";";
     $build .= $getter_func . "";
     $build .= $setter_func . "";
-    
-    # Declare property
-    # TODO: Put this where it's really supposed to go
-
-    $build .= "\@interface " . $property->class . " () \@property (";
-
-    for(my $i = 0; $i < $property->numattr; $i++){
-        my $attr = $property->attributes->[$i];
-
-        if($i != 0){
-            $build .= ", ";
-        }
-
-        $build .= $attr;
-    }
-
-    $build .= ") " . $property->type . " " . $property->name . "; \@end";
 
 
     return $build;

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -1,0 +1,188 @@
+package Logos::Generator::Base::Property;
+use strict;
+use Logos::Util;
+
+sub key {
+    my $self = shift;
+    my $property = shift;
+
+    my $build = "_logos_property_key\$" . $property->group . "\$" . $property->class . "\$" . $property->name;
+
+    return $build;
+}
+
+sub getter {
+    my $self = shift;
+    my $property = shift;
+    my $name = shift;
+    my $key = shift;
+
+    if(!$name){
+        # Use property name if no getter specified
+        $name = $property->name;
+    }
+
+    my $build = "static " . $property->type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd)";
+
+    $build .= "{ return objc_getAssociatedObject(self, &" . $key . "); ";
+
+    $build .= "}";
+
+    return $build;
+}
+
+sub setter {
+    my $self = shift;
+    my $property = shift;
+    my $name = shift;
+    my $policy = shift;
+    my $key = shift;
+
+    if(!$name){
+        # Capitalize first letter
+        $_ = $property->name;
+        $_ =~ s/^([a-z])/\u$1/;
+
+        $name = "set" . $_;
+
+    }
+
+    my $build = "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd, " . $property->type . " arg)";
+
+    $build .= "{ objc_setAssociatedObject(self, &" . $key . ", arg, " . $policy . "); ";
+
+    $build .= "}";
+
+    return $build;
+}
+
+sub getters_setters {
+	my $self = shift;
+	my $property = shift;
+
+	my ($assign, $retain, $nonatomic, $copy, $getter, $setter);
+
+
+    for(my $i = 0; $i < $property->numattr; $i++){
+
+        my $attr = $property->attributes->[$i];
+
+    	if($attr =~ /assign/){
+    		$assign = 1;
+    	}elsif($attr =~ /retain/){
+    		$retain = 1;
+    	}elsif($attr =~ /nonatomic/){
+    		$nonatomic = 1;
+    	}elsif($attr =~ /copy/){
+    		$copy = 1;
+    	}elsif($attr =~ /getter=(\w+)/){
+            $getter = $1;
+        }elsif($attr =~ /setter=(\w+:)/){
+            $setter = $1;
+        }
+    }
+
+    my $policy = "OBJC_ASSOCIATION_";
+
+    if($retain){
+    	$policy .= "RETAIN";
+    }elsif($copy){
+    	$policy .= "COPY";
+    }elsif($assign){
+    	$policy .= "ASSIGN";
+    }else{
+        print "error: no 'assign', 'retain', or 'copy' attribu...wait, how did you manage to get here?\n";
+    }
+
+    if($nonatomic){
+        # The 'assign' attribute appears to be nonatomic by default.
+        if(!$assign){
+            $policy .= "_NONATOMIC";
+        }
+    }
+
+    $property->associationPolicy($policy);
+
+    my $build;
+
+    my $key = $self->key($property);
+    my $getter_func = $self->getter($property, $getter, $key);
+    my $setter_func = $self->setter($property, $setter, $policy, $key);
+
+    $build .= $build . "static char " . $key . ";";
+    $build .= $getter_func . "";
+    $build .= $setter_func . "";
+    
+    # Declare property
+    # TODO: Put this where it's really supposed to go
+
+    $build .= "\@interface " . $property->class . " () \@property (";
+
+    for(my $i = 0; $i < $property->numattr; $i++){
+        my $attr = $property->attributes->[$i];
+
+        if($i != 0){
+            $build .= ", ";
+        }
+
+        $build .= $attr;
+    }
+
+    $build .= ") " . $property->type . " " . $property->name . "; \@end";
+
+
+    return $build;
+}
+
+sub initializers {
+    my $self = shift;
+    my $property = shift;
+
+    my ($getter, $setter); 
+
+    for(my $i = 0; $i < $property->numattr; $i++){ # This could be more efficient
+        my $attr = $property->attributes->[$i];
+
+        if($attr =~ /getter=(\w+)/){
+            $getter = $1;
+        }elsif($attr =~ /setter=(\w+:)/){
+            $setter = $1;
+        }
+    }
+
+    if(!$setter){
+        # Capitalize first letter
+        $_ = $property->name;
+        $_ =~ s/^([a-z])/\u$1/;
+
+        $setter = "set" . $_;
+    }
+
+    if(!$getter){
+        # Use property name if no getter specified
+        $getter = $property->name;
+    }
+
+
+    my $build = "";
+
+    $build .= "{ ";
+
+    # Getter
+    $build .= "class_addMethod(";
+
+    $build .= "_logos_class\$" . $property->group . "\$" . $property->class . ", ";
+    $build .= "\@selector(" . $getter . "), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $getter . "\$, \"@@\:\");";
+
+    # Setter
+    $build .= "class_addMethod(";
+    $build .= "_logos_class\$" . $property->group . "\$" . $property->class . ", ";
+
+    $build .= "\@selector(" . $setter . ":), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $setter . "\$, \"v@\:@\");";
+
+    $build .= "} ";
+
+    return $build;
+}
+
+1;

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -58,8 +58,10 @@ sub setter {
         $_ =~ s/^([a-z])/\u$1/;
 
         $name = "set" . $_;
-
     }
+
+    # Remove semicolon
+    $name =~ s/://;
 
     my $build = "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd, " . $property->type . " arg){ ";
 
@@ -157,6 +159,7 @@ sub initializers {
             $getter = $1;
         }elsif($attr =~ /setter=(\w+:)/){
             $setter = $1;
+            $setter =~ s/://;
         }
     }
 

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -22,11 +22,25 @@ sub getter {
         $name = $property->name;
     }
 
-    my $build = "static " . $property->type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd)";
+    # Build function start
+    my $build = "static " . $property->type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd){";
 
-    $build .= "{ return objc_getAssociatedObject(self, &" . $key . "); ";
+    # Build function body
 
-    $build .= "}";
+    $build .= " return ";
+
+
+    if ($property->type =~ /BOOL/){
+        $build .= "[";
+    }
+
+    $build .= "objc_getAssociatedObject(self, &" . $key . ")";
+
+    if ($property->type =~ /BOOL/){
+        $build .= " boolValue]";
+    }
+
+    $build .= "; }";
 
     return $build;
 }
@@ -47,11 +61,24 @@ sub setter {
 
     }
 
-    my $build = "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd, " . $property->type . " arg)";
+    my $build = "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd, " . $property->type . " arg){ ";
 
-    $build .= "{ objc_setAssociatedObject(self, &" . $key . ", arg, " . $policy . "); ";
 
-    $build .= "}";
+    $build .= "objc_setAssociatedObject(self, &" . $key . ", ";
+
+    if ($property->type =~ /BOOL/){
+        $build .= "[NSNumber numberWithBool:";
+    }
+
+    $build .= "arg";
+
+    if ($property->type =~ /BOOL/){
+        $build .= "]";
+    }
+
+    $build .= ", ".$policy.")";
+
+    $build .= "; }";
 
     return $build;
 }

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -185,13 +185,13 @@ sub initializers {
     $build .= "class_addMethod(";
 
     $build .= "_logos_class\$" . $property->group . "\$" . $property->class . ", ";
-    $build .= "\@selector(" . $getter . "), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $getter . "\$, \"@@\:\");";
+    $build .= "\@selector(" . $getter . "), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $getter . "\$, [[NSString stringWithFormat:\@\"%s\@:\", \@encode(".$property->type.")] UTF8String]);";
 
     # Setter
     $build .= "class_addMethod(";
     $build .= "_logos_class\$" . $property->group . "\$" . $property->class . ", ";
 
-    $build .= "\@selector(" . $setter . ":), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $setter . "\$, \"v@\:@\");";
+    $build .= "\@selector(" . $setter . ":), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $setter . "\$, [[NSString stringWithFormat:\@\"v\@:%s\", \@encode(".$property->type.")] UTF8String]);";
 
     $build .= "} ";
 

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -137,8 +137,8 @@ sub getters_setters {
     my $setter_func = $self->setter($property, $setter, $policy, $key);
 
     $build .= $build . "static char " . $key . ";";
-    $build .= $getter_func . "";
-    $build .= $setter_func . "";
+    $build .= $getter_func;
+    $build .= $setter_func;
 
 
     return $build;

--- a/bin/lib/Logos/Property.pm
+++ b/bin/lib/Logos/Property.pm
@@ -1,0 +1,69 @@
+package Logos::Property;
+use strict;
+
+##################### #
+# Setters and Getters #
+# #####################
+
+sub new{
+	my $proto = shift;
+	my $class = ref($proto) || $proto;
+	my $self = {};
+	$self->{CLASS} = undef;
+	$self->{GROUP} = undef;
+	$self->{NAME} = undef;
+	$self->{TYPE} = undef;
+	$self->{NUMATTR} = undef;
+	$self->{ASSOCIATIONPOLICY} = undef;
+	$self->{ATTRIBUTES} = [];
+	bless($self, $class);
+	return $self;
+}
+
+sub class {
+	my $self = shift;
+	if(@_) { $self->{CLASS} = shift; }
+	return $self->{CLASS};
+}
+
+sub group {
+	my $self = shift;
+	if(@_) { $self->{GROUP} = shift; }
+	return $self->{GROUP};
+}
+
+sub name {
+	my $self = shift;
+	if(@_) { $self->{NAME} = shift; }
+	return $self->{NAME};
+}
+
+sub type {
+	my $self = shift;
+	if(@_) { $self->{TYPE} = shift; }
+	return $self->{TYPE};
+}
+
+sub numattr {
+	my $self = shift;
+	if(@_) { $self->{NUMATTR} = shift; }
+	return $self->{NUMATTR};
+}
+
+sub attributes {
+	my $self = shift;
+	if(@_) { @{$self->{ATTRIBUTES}} = @_; }
+	return $self->{ATTRIBUTES};
+}
+
+sub associationPolicy {
+	my $self = shift;
+	if (@_) { $self->{ASSOCIATIONPOLICY} = shift; }
+	return $self->{ASSOCIATIONPOLICY};
+}
+
+##### #
+# END #
+# #####
+
+1;

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -25,6 +25,7 @@ use aliased 'Logos::Method';
 use aliased 'Logos::Class';
 use aliased 'Logos::Subclass';
 use aliased 'Logos::StaticClassGroup' ;
+use aliased 'Logos::Property';
 
 use Logos::Generator;
 
@@ -520,7 +521,80 @@ foreach my $line (@lines) {
 		} elsif($line =~ /\G%config\s*\(\s*(\w+)\s*=\s*(.*?)\s*\)/gc) {
 			$main::CONFIG{$1} = $2;
 			patchHere(undef);
-		}
+		} elsif($line =~ /\G%property\s*(?:\((\s*\w+\s*(?:,\s*(?:\w|\=)+\s*)*)\))?\s*((?:\w+\s+\*?)+)(\w+)\s*;/gc){
+            nestingMustContain($lineno, "%property", \@nestingstack, "hook", "subclass");
+
+            # check property attribute validity
+		    my @attributes = split/\(?\s*,\s*\)?/, $1;
+            my ($assign, $retain, $copy, $nonatomic, $getter, $setter);
+            my $numattr = 0;
+
+            foreach(@attributes){
+            	$numattr++;
+
+            	if($_ =~ /assign/){
+            		$assign = 1;
+            	}elsif($_ =~ /retain/){
+            		$retain = 1;
+            	}elsif($_ =~ /copy/){
+            		$copy = 1;
+            	}elsif($_ =~ /nonatomic/){
+            		$nonatomic = 1;
+            	}elsif($_ =~ /getter=(\w+)/){
+            		$getter = $1;
+            	}elsif($_ =~ /setter=(\w+:)/){
+            		$setter = $1;
+            	}elsif($_ =~ /readwrite|readonly/){
+            		fileError($lineno, "property attribute '".$_."' not supported.");
+            	}else{
+            		fileError($lineno, "unknown property attribute '".$_."'.");
+            	}
+            }
+
+            if(!$assign && !$retain && !$copy){
+            	fileWarning($lineno, "no 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed");
+            	push(@attributes, "assign");
+            	$numattr++;
+            }
+
+            if($assign && $retain){
+            	fileError($lineno, "property attributes 'assign' and 'retain' are mutually exclusive.");
+            }
+
+            if($assign && $copy){
+            	fileError($lineno, "property attributes 'assign' and 'copy' are mutually exclusive.");
+            }
+
+            if($copy && $retain){
+            	fileError($lineno, "property attributes 'copy' and 'retain' are mutually exclusive.");
+            }
+
+            my $property = Property->new();
+
+
+            $property->class($currentClass->name);
+
+            if($currentGroup){
+            	$property->group($currentGroup->name);
+            }else{
+            	$property->group("_ungrouped");
+            }
+           
+            $property->numattr($numattr);
+            $property->attributes(@attributes);
+            $property->type($2);
+            $property->name($3);
+
+            $currentClass->addProperty($property);
+
+            my $patchStart = $-[0];
+            my $patch = Patch->new();
+			$patch->line($lineno);
+			$patch->range($patchStart, pos($line));
+			$patch->source(Patch::Source::Generator->new($property, 'getters_setters'));
+			addPatch($patch);
+
+        }
 	}
 
 	$lineno++;

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -521,7 +521,7 @@ foreach my $line (@lines) {
 		} elsif($line =~ /\G%config\s*\(\s*(\w+)\s*=\s*(.*?)\s*\)/gc) {
 			$main::CONFIG{$1} = $2;
 			patchHere(undef);
-		} elsif($line =~ /\G%property\s*(?:\((\s*\w+\s*(?:,\s*(?:\w|\=)+\s*)*)\))?\s*((?:\w+\s+\*?)+)(\w+)\s*;/gc){
+		} elsif($line =~ /\G%property\s*(?:\((\s*\w+\s*(?:,\s*(?:\w|\=|:)+\s*)*)\))?\s*((?:\w+\s+\**)+)(\w+)\s*;/gc){
             nestingMustContain($lineno, "%property", \@nestingstack, "hook", "subclass");
 
             # check property attribute validity


### PR DESCRIPTION
I've added a %property directive to Logos. It follows the same syntax as the @property directive.

It creates a fast way to emulate ivars in hooked classes. It adds getter and setter methods, which use Objective-C associated objects as the backend. It only supports Objective-C objects at the moment, but it may be possible to store C types.

Supports the following property attributes:

assign
retain
copy
nonatomic
getter

The 'setter' attribute will be implemented soon.

Consider merging my additions?