### PR TITLE
[Logos] Generate getters & setters for %property even if it is never accessed

### DIFF
--- a/bin/lib/Logos/Class.pm
+++ b/bin/lib/Logos/Class.pm
@@ -98,7 +98,7 @@ sub properties {
 
 sub initRequired {
 	my $self = shift;
-	return $self->required || scalar @{$self->{METHODS}} > 0;
+	return $self->required || scalar @{$self->{METHODS}} > 0 || scalar @{$self->{PROPERTIES}} > 0;
 }
 
 ##### #

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -26,9 +26,9 @@ sub getter {
 	}
 
 	# Build function start
-    my $build = "\n__attribute__((used))\n"; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
-    
-    $build .= "static " . $type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd){";
+	my $build = "\n__attribute__((used))\n"; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+
+	$build .= "static " . $type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd){";
 
 	# Build function body
 
@@ -101,12 +101,12 @@ sub setter {
 	# Remove semicolon
 	$name =~ s/://;
 
-    # Build function start
-    
-    my $build = "\n__attribute__((used))\n"; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+	# Build function start
+
+	my $build = "\n__attribute__((used))\n"; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
 	$build .= "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd, " . $type . " arg){ ";
 
-    # Build function body
+	# Build function body
 
 	$build .= "objc_setAssociatedObject(self, &" . $key . ", ";
 

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -26,7 +26,9 @@ sub getter {
 	}
 
 	# Build function start
-	my $build = "static " . $type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd){";
+    my $build = "\n__attribute__((used))\n"; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+    
+    $build .= "static " . $type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd){";
 
 	# Build function body
 
@@ -99,8 +101,12 @@ sub setter {
 	# Remove semicolon
 	$name =~ s/://;
 
-	my $build = "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd, " . $type . " arg){ ";
+    # Build function start
+    
+    my $build = "\n__attribute__((used))\n"; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+	$build .= "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd, " . $type . " arg){ ";
 
+    # Build function body
 
 	$build .= "objc_setAssociatedObject(self, &" . $key . ", ";
 

--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -26,7 +26,7 @@ sub getter {
 	}
 
 	# Build function start
-	my $build = "\n__attribute__((used))\n"; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+	my $build = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
 
 	$build .= "static " . $type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd){";
 
@@ -103,7 +103,7 @@ sub setter {
 
 	# Build function start
 
-	my $build = "\n__attribute__((used))\n"; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+	my $build = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
 	$build .= "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* self, SEL _cmd, " . $type . " arg){ ";
 
 	# Build function body

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -566,6 +566,8 @@ foreach my $line (@lines) {
 		} elsif($line =~ /\G%property\s*(?:\((\s*\w+\s*(?:,\s*(?:\w|\=|:)+\s*)*)\))?\s*((?:\w+\s+\**)+)(\w+)\s*;/gc){
 			nestingMustContain($lineno, "%property", \@nestingstack, "hook", "subclass");
 
+			$currentClass->hasinstancehooks(1);
+
 			# check property attribute validity
 			my @attributes = split/\(?\s*,\s*\)?/, $1;
 			my ($assign, $retain, $copy, $nonatomic, $getter, $setter);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes an issue where `%property` getters & setters were removed by Clang's optimizer if the property was never accessed.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------


Any other comments?
-------------------
`%property` is awesome, we should keep improving it.

Where has this been tested?
---------------------------
**Operating System:** OS X 10.11

**Platform:** Uh...

**Target Platform:** iOS

**Toolchain Version:** Apple LLVM 7.0.2

**SDK Version:** iOS 9.2