### PR TITLE
*Fix property generator to allow valid setter construction for types …

### DIFF
--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -137,7 +137,7 @@ sub setter {
 	} elsif ($type eq "unsigned short"){
 		$build .= "[NSNumber numberWithUnsignedShort:";
 	} elsif ($type =~ /^(NSRange|CGPoint|CGVector|CGSize|CGRect|CGAffineTransform|UIEdgeInsets|UIOffset|CATransform3D|CMTime(Range|Mapping)?|MKCoordinate(Span)?|SCNVector[34]|SCNMatrix4)$/){
-		$build .= "[NSValue valueWith " . $type . ":";
+		$build .= "[NSValue valueWith" . $type . ":";
 	} else {
 		$hasOpening = 0;
 	}


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Pretty simple, the generated method for the associated type contains a space, which is invalid syntax and breaks compilation. This removes the space, allowing definition of properties that are converted to NSValue. 

Does this close any currently open issues?
------------------------------------------
N/A


Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Where has this been tested?
---------------------------
**Operating System:** OS X

**Platform:** Mac

**Target Platform:** N/A

**Toolchain Version:** Apple LLVM version 7.0.2 (clang-700.1.81)

**SDK Version:** 9.2