### PR TITLE
[Logos] Fixed nil class spam

### DIFF
--- a/bin/lib/Logos/Generator/MobileSubstrate/Method.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Method.pm
@@ -84,7 +84,9 @@ sub initializers {
 		$r .= "if (".$classvar.") {";
 		$r .=   "MSHookMessageEx(".$classvar.", ".$self->selectorRef($method->selector).", (IMP)&".$self->newFunctionName($method).", (IMP*)&".$self->originalFunctionName($method).");";
 		$r .= "} else {";
+		$r .= "#ifdef __DEBUG__";
 		$r .=   "HBLogError(@\"logos: nil class %s\", \"".$method->class->name."\");";
+		$r .= "#endif";
 		$r .= "}";
 	} else {
 		my $r = "";

--- a/bin/lib/Logos/Generator/internal/Method.pm
+++ b/bin/lib/Logos/Generator/internal/Method.pm
@@ -109,7 +109,9 @@ sub initializers {
 		$r .=     "HBLogError(@\"logos: message not found [%s %s]\", \"".$method->class->name."\", \"".$method->selector."\");";
 		$r .=   "}";
 		$r .= "} else {";
+		$r .= "#ifdef __DEBUG__";
 		$r .=   "HBLogError(@\"logos: nil class %s\", \"".$method->class->name."\");";
+		$r .= "#endif";
 		$r .= "}";
 	} else {
 		if(!$method->type) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes constant spam to the syslog when a class cannot be found.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------

`[Tweak: Tweak.xm:<line>] ERROR: logos: nil class <class>`

Any other comments?
-------------------
Only stops error from being shown if binary is built in production (non-debug) mode.

