### PR TITLE
[package] Exclude symbolic file for pincrush target.

### DIFF
--- a/makefiles/package.mk
+++ b/makefiles/package.mk
@@ -8,7 +8,7 @@ package:: internal-package-check stage before-package internal-package after-pac
 before-package:: $(THEOS_PACKAGE_DIR)
 internal-package::
 ifeq ($(_THEOS_FINAL_PACKAGE),$(_THEOS_TRUE))
-	find $(THEOS_STAGING_DIR) -name \*.png -exec pincrush -i {} \;
+	find $(THEOS_STAGING_DIR) -name \*.png -a ! -type l -exec pincrush -i {} \;
 	find $(THEOS_STAGING_DIR) \( -name \*.plist -or -name \*.strings \) -exec plutil -convert binary1 {} \;
 endif
 internal-package-check::


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
To avoid pincrush `could not open` error.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
```
find /Users/hyde/dev/sleipnizer/.theos/_ -name \*.png -exec pincrush -i {} \;
/Users/hyde/dev/sleipnizer/.theos/_/Applications/MobileSafari.app/SleipnizerSettings.png: Error: could not open.
/Users/hyde/dev/sleipnizer/.theos/_/Applications/MobileSafari.app/SleipnizerSettings@2x.png: Error: could not open.
/Users/hyde/dev/sleipnizer/.theos/_/Applications/MobileSafari.app/SleipnizerSettings@3x.png: Error: could not open.
```
These files are symlink.

```
~/dev/sleipnizer (master)$ ll /Users/hyde/dev/sleipnizer/.theos/_/Applications/MobileSafari.app/SleipnizerSettings.png
lrwxr-xr-x  1 hyde  staff  67 12  7  2014 /Users/hyde/dev/sleipnizer/.theos/_/Applications/MobileSafari.app/SleipnizerSettings.png@ -> /Library/PreferenceBundles/SleipnizerSettings.bundle/Sleipnizer.png
```

Any other comments?
-------------------
Nothing.

Where has this been tested?
---------------------------
**Operating System:** OS X El Capitan 10.11.6

**Platform:** OS X

**Target Platform:** iOS

**Toolchain Version:** Xcode 7.2

**SDK Version:** 9.3

