### PR TITLE
Version Edge Case Fix

### DIFF
--- a/makefiles/package/deb.mk
+++ b/makefiles/package/deb.mk
@@ -29,7 +29,7 @@ ifeq ($(_THEOS_HAS_STAGING_LAYOUT),1) # If we have a layout directory, copy layo
 endif # _THEOS_HAS_STAGING_LAYOUT
 
 $(_THEOS_ESCAPED_STAGING_DIR)/DEBIAN/control: $(_THEOS_ESCAPED_STAGING_DIR)/DEBIAN
-	$(ECHO_NOTHING)sed -e '/^[Vv]ersion:/d' "$(_THEOS_DEB_PACKAGE_CONTROL_PATH)" > "$@"$(ECHO_END)
+	$(ECHO_NOTHING)sed -e '/^[Vv]ersion:/d; /^$$/d; $$a\' "$(_THEOS_DEB_PACKAGE_CONTROL_PATH)" > "$@"$(ECHO_END)
 	$(ECHO_NOTHING)echo "Version: $(_THEOS_INTERNAL_PACKAGE_VERSION)" >> "$@"$(ECHO_END)
 	$(ECHO_NOTHING)echo "Installed-Size: $(shell $(_THEOS_PLATFORM_DU) $(_THEOS_PLATFORM_DU_EXCLUDE) DEBIAN -ks "$(THEOS_STAGING_DIR)" | cut -f 1)" >> "$@"$(ECHO_END)
 


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------

There was an edge case where if a control file did not contain an empty line it would get the version appended on the same line as another control field, leading to dpkg-deb throwing the error that no Version was present in the control file. This also handles if a control file has multiple empty lines at its end, they will be removed and a new line ending will be appended to that last line if one is not already present.

Does this close any currently open issues?
------------------------------------------

No


Any relevant logs, error output, etc?
-------------------------------------

No

Any other comments?
-------------------

Nope

Where has this been tested?
---------------------------

**Operating System:** Ubuntu 14.04

**Platform:** Linux

**Target Platform:** iOS

**Toolchain Version:** Latest?

**SDK Version:** 9.2

---------------------------

**Operating System:** OS X 10.11.5

**Platform:** Mac

**Target Platform:** iOS

**Toolchain Version:** Latest?

**SDK Version:** 9.2

---------------------------

**Operating System:** Windows 10

**Platform:** Windows

**Target Platform:** iOS

**Toolchain Version:** Latest?

**SDK Version:** 9.2