### PR TITLE
Fix %subclass Protocol Issue

### DIFF
--- a/bin/lib/Logos/Generator/MobileSubstrate/Subclass.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Subclass.pm
@@ -23,7 +23,7 @@ sub initializers {
 	}
 	# </ivars>
 	foreach(keys %{$class->protocols}) {
-		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\")); ";
+		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\") ?: \@protocol($_)); ";
 	}
 	$return .= "}";
 	return $return;

--- a/bin/lib/Logos/Generator/internal/Subclass.pm
+++ b/bin/lib/Logos/Generator/internal/Subclass.pm
@@ -24,7 +24,7 @@ sub initializers {
 	# </ivars>
 	$return .= "objc_registerClassPair(".$self->variable($class)."); ";
 	foreach(keys %{$class->protocols}) {
-		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\")); ";
+		$return .= "class_addProtocol(".$self->variable($class).", objc_getProtocol(\"$_\") ?: \@protocol($_)); ";
 	}
 	$return .= "}";
 	return $return;


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
## What does this implement/fix? Explain your changes.

The changes to Subclass.pm fix a issue where calling: 

```
objc_getProtocol("PROTOCOL_NAME") 
```

Isn't always guaranteed to return an Protocol Object as per Documentation found [here](https://developer.apple.com/legacy/library/documentation/Cocoa/Conceptual/ObjectiveC/Chapters/ocProtocols.html#//apple_ref/doc/uid/TP30001163-CH15-TPXREF149). 

> Protocols that are declared but not used (except for type checking as described below) aren’t represented by protocol objects at runtime.

The changes in Subclass.pm use an ternary operator to check if **objc_getProtocol("") *\* returns null, if it does then **@protocol()** is used to get an Protocol Object.

This was tested to work using the code found [here](https://ghostbin.com/paste/3rzwy).
## Does this close any currently open issues?

Yes, it closes Issue #114 and is a followup to pull request #115 that fixes its reason for not being merged into the master branch
## Any relevant logs, error output, etc?

Nope not really
## Any other comments?

Not that I can think of
## Where has this been tested?

**Operating System:** OS X 10.11.5

**Platform:** macOS

**Target Platform:** iOS

**Toolchain Version:** Latest?

**SDK Version:** 9.2

---

**Operating System:** Windows 10

**Platform:** Windows

**Target Platform:** iOS

**Toolchain Version:** Latest?

**SDK Version:** 9.2

---

**Operating System:** Ubuntu 14.04

**Platform:** Linux

**Target Platform:** iOS

**Toolchain Version:** Latest?

**SDK Version:** 9.2
