### PR TITLE
[logos] Add support for dynamic lookup of functions in %hookf.

### DIFF
--- a/bin/lib/Logos/Generator/Base/Function.pm
+++ b/bin/lib/Logos/Generator/Base/Function.pm
@@ -3,16 +3,23 @@ use strict;
 use Logos::Generator;
 use Logos::Util;
 
+sub getLiteralOrLookupFunctionName {
+	my $self = shift;
+	my $name = shift;
+	return "lookup\$".substr($name, 1, -1) if (substr($name, 0, 1) eq "\"" && substr($name, -1, 1) eq "\"");
+	return $name;
+}
+
 sub originalFunctionName {
 	my $self = shift;
 	my $function = shift;
-	return Logos::sigil("orig").$function->group->name."\$".$function->name;
+	return Logos::sigil("orig").$function->group->name."\$".$self->getLiteralOrLookupFunctionName($function->name);
 }
 
 sub newFunctionName {
 	my $self = shift;
 	my $function = shift;
-	return Logos::sigil("function").$function->group->name."\$".$function->name;
+	return Logos::sigil("function").$function->group->name."\$".$self->getLiteralOrLookupFunctionName($function->name);
 }
 
 sub originalFunctionCall {

--- a/bin/lib/Logos/Generator/MobileSubstrate/Function.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Function.pm
@@ -7,7 +7,12 @@ sub initializers {
 	my $function = shift;
 
 	my $return = "";
-	$return .= " MSHookFunction((void *)".$function->name;
+	$return .= " MSHookFunction((void *)";
+	if (substr($function->name, 0, 1) eq "\"") {
+		$return .= "MSFindSymbol(NULL, ".$function->name.")";
+	} else {
+		$return .= $function->name;
+	}
 	$return .= ", (void *)&".$self->newFunctionName($function);
 	$return .= ", (void **)&".$self->originalFunctionName($function);
 	$return .= ");";

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -23,7 +23,7 @@ use aliased 'Logos::Group';
 use aliased 'Logos::Method';
 use aliased 'Logos::Class';
 use aliased 'Logos::Subclass';
-use aliased 'Logos::StaticClassGroup' ;
+use aliased 'Logos::StaticClassGroup';
 use aliased 'Logos::Property';
 use aliased 'Logos::Function';
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds support for `%hookf` such that if the given function name is surrounded with `"` the function is dynamically looked up with `MSFindSymbol`. This helps ease writing hooks for mangled functions.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
-

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** iOS

**Platform:** iOS

**Target Platform:** All

**Toolchain Version:** N/A

**SDK Version:** N/A

