### PR TITLE
Add support for the new arm64 Windows/Linux toolchain

### DIFF
--- a/makefiles/platform/Linux.mk
+++ b/makefiles/platform/Linux.mk
@@ -6,7 +6,7 @@ _THEOS_PLATFORM_DEFAULT_TARGET := iphone
 _THEOS_PLATFORM_DU_EXCLUDE := --exclude
 _THEOS_PLATFORM_MD5SUM := md5sum
 # TODO: Figure out if hardcoding "/iphone/" in _THEOS_PLATFORM_LIPO's path is a good idea or not
-_THEOS_PLATFORM_LIPO = $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/iphone/bin/armv7-apple-darwin11-lipo
+_THEOS_PLATFORM_LIPO = $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/iphone/bin/$(SDKTARGET)-lipo
 # TODO: Find some better way to determine _THEOS_PLATFORM_SHOW_IN_FILE_MANAGER, as not all desktop environments use Nautilus as the file manager
 _THEOS_PLATFORM_SHOW_IN_FILE_MANAGER := nautilus
 endif

--- a/makefiles/platform/Windows.mk
+++ b/makefiles/platform/Windows.mk
@@ -8,6 +8,6 @@ _THEOS_PLATFORM_DPKG_DEB := dm.pl
 _THEOS_PLATFORM_DPKG_DEB_COMPRESSION := gzip
 _THEOS_PLATFORM_MD5SUM := md5sum
 # TODO: Figure out if hardcoding "/iphone/" in _THEOS_PLATFORM_LIPO's path is a good idea or not
-_THEOS_PLATFORM_LIPO = $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/iphone/bin/armv7-apple-darwin11-lipo
+_THEOS_PLATFORM_LIPO = $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/iphone/bin/$(SDKTARGET)-lipo
 _THEOS_PLATFORM_SHOW_IN_FILE_MANAGER := explorer /select,
 endif

--- a/makefiles/targets/Linux/iphone.mk
+++ b/makefiles/targets/Linux/iphone.mk
@@ -2,7 +2,16 @@ ifeq ($(_THEOS_TARGET_LOADED),)
 _THEOS_TARGET_LOADED := 1
 THEOS_TARGET_NAME := iphone
 
-SDKTARGET ?= armv7-apple-darwin11
+#SDKTARGET ?= armv7-apple-darwin11
+# test if bin/arm64-apple-darwin14-ld exists.
+ifeq (,$(wildcard $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin/arm64-apple-darwin14-ld))
+	 # if not, use the old toolchain
+	SDKTARGET ?= armv7-apple-darwin11
+else
+	# if it does, use the new toolchain
+	SDKTARGET ?= arm64-apple-darwin14
+endif
+
 SDKBINPATH ?= $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin
 
 _THEOS_TARGET_CC := clang

--- a/makefiles/targets/Windows/iphone.mk
+++ b/makefiles/targets/Windows/iphone.mk
@@ -2,7 +2,16 @@ ifeq ($(_THEOS_TARGET_LOADED),)
 _THEOS_TARGET_LOADED := 1
 THEOS_TARGET_NAME := iphone
 
-SDKTARGET ?= armv7-apple-darwin11
+#SDKTARGET ?= armv7-apple-darwin11
+# test if bin/arm64-apple-darwin14-ld exists.
+ifeq (,$(wildcard $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin/arm64-apple-darwin14-ld))
+	 # if not, use the old toolchain
+	SDKTARGET ?= armv7-apple-darwin11
+else
+	# if it does, use the new toolchain
+	SDKTARGET ?= arm64-apple-darwin14
+endif
+
 SDKBINPATH ?= $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin
 
 _THEOS_TARGET_CC := clang


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes this error when using coolstar's new toolchain

`... /iphone/bin/armv7-apple-darwin11-clang++: No such file or directory`

The change set the SDKTARGET variable by checking if arm64-apple-darwin14-ld exists or not.
Then uses SDKTARGET to set _THEOS_PLATFORM_LIPO.

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …
- Windows 10 + Cygwin
- Ubuntu Linux

**Platform:** …
- Windows & Linux

**Target Platform:** …
- iOS/iPhone

**Toolchain Version:** …

- Previous toolchain with the armv7-apple-darwin11* binaries
- Current toolchain with the arm64-apple-darwin14* binaries

**SDK Version:** …