### PR TITLE
[theos/bin/logos.pl] Added unicode support* for theos.

### DIFF
--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -224,7 +224,7 @@ foreach my $line (@lines) {
 		$directiveDepth = 0 if(!@directiveDepthTokens);
 		$directiveDepth = $depthsForCurrentLine{join(':', @directiveDepthTokens)} if @directiveDepthTokens;
 
-		if($line =~ /\G%hook\s+([\$_\w]+)/gc) {
+		if($line =~ /\G%hook\s+([^\s]+)/gc) {
 			# "%hook <identifier>"
 			fileError($lineno, "%hook does not make sense inside a block") if($directiveDepth >= 1);
 			nestingMustNotContain($lineno, "%hook", \@nestingstack, "hook", "subclass");
@@ -236,7 +236,7 @@ foreach my $line (@lines) {
 			$currentClass = $currentGroup->addClassNamed($1);
 			$classes{$currentClass->name}++;
 			patchHere(undef);
-		} elsif($line =~ /\G%subclass\s+([\$_\w]+)\s*:\s*([\$_\w]+)\s*(\<\s*(.*?)\s*\>)?/gc) {
+		} elsif($line =~ /\G%subclass\s+([^\s]+)\s*:\s*([^\s]+)\s*(\<\s*(.*?)\s*\>)?/gc) {
 			# %subclass <identifier> : <identifier> \<<protocols ...>\>
 			fileError($lineno, "%subclass does not make sense inside a block") if($directiveDepth >= 1);
 			nestingMustNotContain($lineno, "%subclass", \@nestingstack, "hook", "subclass");
@@ -265,7 +265,7 @@ foreach my $line (@lines) {
 			$classes{$classname}++;
 
 			patchHere(undef);
-		} elsif($line =~ /\G%group\s+([\$_\w]+)/gc) {
+		} elsif($line =~ /\G%group\s+([^\s]+)/gc) {
 			# %group <identifier>
 			fileError($lineno, "%group does not make sense inside a block") if($directiveDepth >= 1);
 			nestingMustNotContain($lineno, "%group", \@nestingstack, "group");
@@ -284,7 +284,7 @@ foreach my $line (@lines) {
 				$patchSource = Patch::Source::Generator->new($capturedGroup, 'declarations');
 			}
 			patchHere($patchSource);
-		} elsif($line =~ /\G%class\s+([+-])?([\$_\w]+)/gc) {
+		} elsif($line =~ /\G%class\s+([+-])?([^\s]+)/gc) {
 			# %class [+-]<identifier>
 			@firstDirectivePosition = ($lineno, $-[0]) if !@firstDirectivePosition;
 
@@ -300,7 +300,7 @@ foreach my $line (@lines) {
 			}
 			$classes{$classname}++;
 			patchHere(undef);
-		} elsif($line =~ /\G%c\(\s*([+-])?([\$_\w]+)\s*\)/gc) {
+		} elsif($line =~ /\G%c\(\s*([+-])?([^\s]+)\s*\)/gc) {
 			# %c([+-]<identifier>)
 			@firstDirectivePosition = ($lineno, $-[0]) if !@firstDirectivePosition;
 
@@ -321,7 +321,7 @@ foreach my $line (@lines) {
 			$xtype = $2 if $2;
 			$newMethodTypeEncoding = $xtype;
 			patchHere(undef);
-		} elsif($currentClass && $line =~ /\G([+-])\s*\(\s*(.*?)\s*\)(?=\s*[\$\w:])/gc && $directiveDepth < 1) {
+		} elsif($currentClass && $line =~ /\G([+-])\s*\(\s*(.*?)\s*\)(?=\s*[^\s])/gc && $directiveDepth < 1) {
 			# [+-] (<return>)<[X:]>, but only when we're in a %hook.
 
 			# Gasp! We've been moved to a different group!
@@ -356,7 +356,7 @@ foreach my $line (@lines) {
 			my $patchStart = $-[0];
 
 			# word, then an optional: ": (argtype)argname"
-			while($line =~ /\G\s*([\$\w]*)(\s*:\s*(\((.+?)\))?\s*([\$\w]+?)\b)?/gc) {
+			while($line =~ /\G\s*([^\s]*)(\s*:\s*(\((.+?)\))?\s*([^\s]+?)\b)?/gc) {
 				if(!$1 && !$2) { # Exit the loop if both Keywords and Args are missing: e.g. false positive.
 					pos($line) = $-[0];
 					last;


### PR DESCRIPTION
[theos/bin/logos.pl] Added unicode support* for theos. 

(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Added unicode support* for theos.

*, You can use any allowed unicode characters in Objective-C.

In real-life, Objective-C accepts unicode characters like Chinese, Japanese, Arabic,  so on and so forth in both class name and method name. 

However, the regex in ```theos/bin/logos.pl``` only matches ```[\$_\w]```, which would emit error if there is any unicode character.

The error message goes like,

```$ make
> Making all for tweak UnicodeHook…
==> Preprocessing Tweak.xm…
==> Compiling Tweak.xm (armv7)…
Tweak.xm:3:1: error: missing context for method declaration
- (id)中文方法名 {
^
1 error generated.
```

So, I just modified the regex pattern, patterns like ```[\$_\w]``` were changed to ```[^\s]```. IMHO, this is good, after all, I believe probably no one would write meaningless ASCII characters in these commands. Even if they do that, the file won't compile.

Affected commands are listed below.

- %hook
- %subclass
- %group
- %class
- %c

Applied these modifications, we got

```
$ export THEOS=~/Git/theos
$ make clean
==> Cleaning…
$ cat Tweak.xm 
%hook UnicodeHook可行

- (id)中文方法名 {
    return %orig;
}

- (id)アルパカ {
    return %orig;
}

- (id)بالعربية {
    return %orig;
}

%end
$ make
> Making all for tweak UnicodeHook…
==> Preprocessing Tweak.xm…
==> Compiling Tweak.xm (armv7)…
==> Linking tweak UnicodeHook (armv7)…
clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of iOS 7 [-Wdeprecated]
==> Preprocessing Tweak.xm…
==> Compiling Tweak.xm (arm64)…
==> Linking tweak UnicodeHook (arm64)…
clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of iOS 7 [-Wdeprecated]
==> Merging tweak UnicodeHook…
==> Signing UnicodeHook…
$ 
```

Does this close any currently open issues?
------------------------------------------
AFAIK, no such related open issues.


Any relevant logs, error output, etc?
-------------------------------------
Before these changes were made, Logos emits error massages.

Tweak.xm,
```
%hook UnicodeHook

- (id)中文方法名 {
}

%end

```

```$ make
> Making all for tweak UnicodeHook…
==> Preprocessing Tweak.xm…
==> Compiling Tweak.xm (armv7)…
Tweak.xm:3:1: error: missing context for method declaration
- (id)中文方法名 {
^
1 error generated.
```


Any other comments?
-------------------
I guess no. Maybe you can refer to my blog post on this topic, [Theos Hook Objective-C classes / methods with Unicode Characters](https://blog.0xbbc.com/2017/04/theos-hook-objective-c-classes-methods-with-unicode-characters/). 

The last screenshot is how the compiled dylib looks like in Hopper, which suggests these modifications
indeed work. 


Where has this been tested?
---------------------------
**Operating System:**
macOS 10.12.4

**Platform:** …
macOS

**Target Platform:** …
iOS/iPhone

- armv7
- arm64

**Toolchain Version:**
toolchain comes with Xcode 8.3 (8E162)

**SDK Version:**
```
$ xcrun --sdk iphoneos --show-sdk-path
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk
```
