### PR TITLE
[Logos] Fix %property parsing of type and name.

### DIFF
--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -563,7 +563,7 @@ foreach my $line (@lines) {
 		} elsif($line =~ /\G%config\s*\(\s*(\w+)\s*=\s*(.*?)\s*\)/gc) {
 			$main::CONFIG{$1} = $2;
 			patchHere(undef);
-		} elsif($line =~ /\G%property\s*(?:\((\s*\w+\s*(?:,\s*(?:\w|\=|:)+\s*)*)\))?\s*((?:\w+\s+\**)+)(\w+)\s*;/gc){
+		} elsif($line =~ /\G%property\s*(?:\((\s*\w+\s*(?:,\s*(?:\w|\=|:)+\s*)*)\))?\s*([a-zA-Z_\$][\w\$]*(?:\s*[a-zA-Z_\$][\w\$]*)*(?:\s*\*+)*)\s*(\b[a-zA-Z_\$][\w\$]*+)\s*;/gc){
 			nestingMustContain($lineno, "%property", \@nestingstack, "hook", "subclass");
 
 			$currentClass->hasinstancehooks(1);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Improves `%property` parsing of type and name.

Does this close any currently open issues?
------------------------------------------
Fixes issue #226.


Any relevant logs, error output, etc?
-------------------------------------
[Test results](https://ghostbin.com/paste/w5gs6)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** iOS 6.1.4

**Platform:** iOS 6.1.4

**Target Platform:** iOS 6.1.4

**Toolchain Version:** Latest available

**SDK Version:** 8.1
