### PR TITLE
[Logos] %property rewrite.

### DIFF
--- a/bin/lib/Logos/Generator/Base/Property.pm
+++ b/bin/lib/Logos/Generator/Base/Property.pm
@@ -2,222 +2,37 @@ package Logos::Generator::Base::Property;
 use strict;
 use Logos::Util;
 
-sub key {
+sub getterName {
 	my $self = shift;
 	my $property = shift;
-
-	my $build = "_logos_property_key\$" . $property->group . "\$" . $property->class . "\$" . $property->name;
-
-	return $build;
+	return Logos::sigil("method").$property->group."\$".$property->class."\$".$property->getter;
 }
 
-sub getter {
+sub setterName {
 	my $self = shift;
 	my $property = shift;
-	my $name = shift;
-	my $key = shift;
-	my $type = $property->type;
-
-	$type =~ s/\s+$//;
-
-	if(!$name){
-		# Use property name if no getter specified
-		$name = $property->name;
-	}
-
-	# Build function start
-	my $build = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
-
-	$build .= "static " . $type . " _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* __unused self, SEL __unused _cmd){";
-
-	# Build function body
-
-	$build .= " return ";
-
-
-	if ($type =~ /^(BOOL|(unsigned )?char|double|float|CGFloat|(unsigned )?int|NSInteger|unsigned|NSUInteger|(unsigned )?long (long)?|(unsigned )?short|NSRange|CGPoint|CGVector|CGSize|CGRect|CGAffineTransform|UIEdgeInsets|UIOffset|CATransform3D|CMTime(Range|Mapping)?|MKCoordinate(Span)?|SCNVector[34]|SCNMatrix4)$/){
-		$build .= "[";
-	}
-
-	$build .= "objc_getAssociatedObject(self, &" . $key . ")";
-
-	if ($type eq "BOOL"){
-		$build .= " boolValue]";
-	} elsif ($type eq "char"){
-		$build .= " charValue]";
-	} elsif ($type eq "unsigned char"){
-		$build .= " unsignedCharValue]";
-	} elsif ($type eq "double"){
-		$build .= " doubleValue]";
-	} elsif ($type =~ /^(float|CGFloat)$/){
-		$build .= " floatValue]";
-	} elsif ($type eq "int"){
-		$build .= " intValue]";
-	} elsif ($type eq "NSInteger"){
-		$build .= " integerValue]";
-	} elsif ($type =~ /^unsigned( int)?$/){
-		$build .= " unsignedIntValue]";
-	} elsif ($type eq "NSUInteger"){
-		$build .= " unsignedIntegerValue]";
-	} elsif ($type eq "long"){
-		$build .= " longValue]";
-	} elsif ($type eq "unsigned long"){
-		$build .= " unsignedLongValue]";
-	} elsif ($type eq "long long"){
-		$build .= " longLongValue]";
-	} elsif ($type eq "unsigned long long"){
-		$build .= " unsignedLongLongValue]";
-	} elsif ($type eq "short"){
-		$build .= " shortValue]";
-	} elsif ($type eq "unsigned short"){
-		$build .= " unsignedShortValue]";
-	} elsif ($type =~ /^(NSRange|CGPoint|CGVector|CGSize|CGRect|CGAffineTransform|UIEdgeInsets|UIOffset|CATransform3D|CMTime(Range|Mapping)?|MKCoordinate(Span)?|SCNVector[34]|SCNMatrix4)$/){
-		$build .= " " . $type . "Value]";
-	}
-
-	$build .= "; }";
-
-	return $build;
+	return Logos::sigil("method").$property->group."\$".$property->class."\$".$property->setter;
 }
 
-sub setter {
-	my $self = shift;
-	my $property = shift;
-	my $name = shift;
-	my $policy = shift;
-	my $key = shift;
-	my $type = $property->type;
-
-	$type =~ s/\s+$//;
-
-	if(!$name){
-		# Capitalize first letter
-		$_ = $property->name;
-		$_ =~ s/^([a-z])/\u$1/;
-
-		$name = "set" . $_;
-	}
-
-	# Remove semicolon
-	$name =~ s/://;
-
-	# Build function start
-
-	my $build = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
-	$build .= "static void _logos_method\$" . $property->group . "\$" . $property->class . "\$" . $name . "\$" . "(" . $property->class . "* __unused self, SEL __unused _cmd, " . $type . " arg){ ";
-
-	# Build function body
-
-	$build .= "objc_setAssociatedObject(self, &" . $key . ", ";
-
-	my $hasOpening = 1;
-
-	if ($type eq "BOOL"){
-		$build .= "[NSNumber numberWithBool:";
-	} elsif ($type eq "char"){
-		$build .= "[NSNumber numberWithChar:";
-	} elsif ($type eq "unsigned char"){
-		$build .= "[NSNumber numberWithUnsignedChar:";
-	} elsif ($type eq "double"){
-		$build .= "[NSNumber numberWithDouble:";
-	} elsif ($type =~ /^(float|CGFloat)$/){
-		$build .= "[NSNumber numberWithFloat:";
-	} elsif ($type eq "int"){
-		$build .= "[NSNumber numberWithInt:";
-	} elsif ($type eq "NSInteger"){
-		$build .= "[NSNumber numberWithInteger:";
-	} elsif ($type =~ /^unsigned( int)?$/){
-		$build .= "[NSNumber numberWithUnsignedInt:";
-	} elsif ($type eq "NSUInteger"){
-		$build .= "[NSNumber numberWithUnsignedInteger:";
-	} elsif ($type eq "long"){
-		$build .= "[NSNumber numberWithLong:";
-	} elsif ($type eq "unsigned long"){
-		$build .= "[NSNumber numberWithUnsignedLong:";
-	} elsif ($type eq "long long"){
-		$build .= "[NSNumber numberWithLongLong:";
-	} elsif ($type eq "unsigned long long"){
-		$build .= "[NSNumber numberWithUnsignedLongLong:";
-	} elsif ($type eq "short"){
-		$build .= "[NSNumber numberWithShort:";
-	} elsif ($type eq "unsigned short"){
-		$build .= "[NSNumber numberWithUnsignedShort:";
-	} elsif ($type =~ /^(NSRange|CGPoint|CGVector|CGSize|CGRect|CGAffineTransform|UIEdgeInsets|UIOffset|CATransform3D|CMTime(Range|Mapping)?|MKCoordinate(Span)?|SCNVector[34]|SCNMatrix4)$/){
-		$build .= "[NSValue valueWith" . $type . ":";
-	} else {
-		$hasOpening = 0;
-	}
-
-	$build .= "arg";
-
-	if ($hasOpening){
-		$build .= "]";
-	}
-
-	$build .= ", ".$policy.")";
-
-	$build .= "; }";
-
-	return $build;
-}
-
-sub getters_setters {
+sub definition {
 	my $self = shift;
 	my $property = shift;
 
-	my ($assign, $retain, $nonatomic, $copy, $getter, $setter);
+	my $build = "";
 
+	# Build getter
+	my $getter_func = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+	$getter_func .= "static ".$property->type." ".$self->getterName($property)."(".$property->class." * __unused self, SEL __unused _cmd) ";
+	$getter_func .= "{ NSValue * value = objc_getAssociatedObject(self, &".$self->getterName($property)."); ".$property->type." rawValue; [value getValue:&rawValue]; return rawValue; }";
 
-	for(my $i = 0; $i < $property->numattr; $i++){
+	# Build setter
+	my $setter_func = "__attribute__((used)) "; # If the property is never accessed, clang's optimizer will remove the getter/setter if this attribute isn't specified
+	$setter_func .= "static void ".$self->setterName($property)."(".$property->class." * __unused self, SEL __unused _cmd, ".$property->type." rawValue) ";
+	$setter_func .= "{ NSValue * value = [NSValue valueWithBytes:&rawValue objCType:\@encode(".$property->type.")]; objc_setAssociatedObject(self, &".$self->getterName($property).", value, ".$property->associationPolicy."); }";
 
-		my $attr = $property->attributes->[$i];
-
-		if($attr =~ /assign/){
-			$assign = 1;
-		}elsif($attr =~ /retain/){
-			$retain = 1;
-		}elsif($attr =~ /nonatomic/){
-			$nonatomic = 1;
-		}elsif($attr =~ /copy/){
-			$copy = 1;
-		}elsif($attr =~ /getter=(\w+)/){
-			$getter = $1;
-		}elsif($attr =~ /setter=(\w+:)/){
-			$setter = $1;
-		}
-	}
-
-	my $policy = "OBJC_ASSOCIATION_";
-
-	if($retain){
-		$policy .= "RETAIN";
-	}elsif($copy){
-		$policy .= "COPY";
-	}elsif($assign){
-		$policy .= "ASSIGN";
-	}else{
-		print "error: no 'assign', 'retain', or 'copy' attribu...wait, how did you manage to get here?\n";
-	}
-
-	if($nonatomic){
-		# The 'assign' attribute appears to be nonatomic by default.
-		if(!$assign){
-			$policy .= "_NONATOMIC";
-		}
-	}
-
-	$property->associationPolicy($policy);
-
-	my $build;
-
-	my $key = $self->key($property);
-	my $getter_func = $self->getter($property, $getter, $key);
-	my $setter_func = $self->setter($property, $setter, $policy, $key);
-
-	$build .= $build . "static char " . $key . ";";
 	$build .= $getter_func;
+	$build .= "; ";
 	$build .= $setter_func;
-
 
 	return $build;
 }
@@ -226,50 +41,25 @@ sub initializers {
 	my $self = shift;
 	my $property = shift;
 
-	my ($getter, $setter);
-
-	for(my $i = 0; $i < $property->numattr; $i++){ # This could be more efficient
-		my $attr = $property->attributes->[$i];
-
-		if($attr =~ /getter=(\w+)/){
-			$getter = $1;
-		}elsif($attr =~ /setter=(\w+:)/){
-			$setter = $1;
-			$setter =~ s/://;
-		}
-	}
-
-	if(!$setter){
-		# Capitalize first letter
-		$_ = $property->name;
-		$_ =~ s/^([a-z])/\u$1/;
-
-		$setter = "set" . $_;
-	}
-
-	if(!$getter){
-		# Use property name if no getter specified
-		$getter = $property->name;
-	}
-
-
-	my $build = "";
-
-	$build .= "{ ";
+	my $build = "{ char _typeEncoding[1024];";
 
 	# Getter
-	$build .= "class_addMethod(";
-
-	$build .= "_logos_class\$" . $property->group . "\$" . $property->class . ", ";
-	$build .= "\@selector(" . $getter . "), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $getter . "\$, [[NSString stringWithFormat:\@\"%s\@:\", \@encode(".$property->type.")] UTF8String]);";
+	$build .= " sprintf(_typeEncoding, \"%s\@:\", \@encode(".$property->type."));";
+	$build .= " class_addMethod(";
+	$build .= Logos::sigil("class").$property->group."\$".$property->class.", ";
+	$build .= "\@selector(".$property->getter."), ";
+	$build .= "(IMP)&".$self->getterName($property).", ";
+	$build .= "_typeEncoding);";
 
 	# Setter
-	$build .= "class_addMethod(";
-	$build .= "_logos_class\$" . $property->group . "\$" . $property->class . ", ";
+	$build .= " sprintf(_typeEncoding, \"v\@:%s\", \@encode(".$property->type."));";
+	$build .= " class_addMethod(";
+	$build .= Logos::sigil("class").$property->group."\$".$property->class.", ";
+	$build .= "\@selector(".$property->setter.":), ";
+	$build .= "(IMP)&".$self->setterName($property).", ";
+	$build .= "_typeEncoding);";
 
-	$build .= "\@selector(" . $setter . ":), " . "(IMP)&" . "_logos_method\$" . $property->group . "\$" . $property->class . "\$" . $setter . "\$, [[NSString stringWithFormat:\@\"v\@:%s\", \@encode(".$property->type.")] UTF8String]);";
-
-	$build .= "} ";
+	$build .= " } ";
 
 	return $build;
 }

--- a/bin/lib/Logos/Property.pm
+++ b/bin/lib/Logos/Property.pm
@@ -5,7 +5,7 @@ use strict;
 # Setters and Getters #
 # #####################
 
-sub new{
+sub new {
 	my $proto = shift;
 	my $class = ref($proto) || $proto;
 	my $self = {};
@@ -13,9 +13,9 @@ sub new{
 	$self->{GROUP} = undef;
 	$self->{NAME} = undef;
 	$self->{TYPE} = undef;
-	$self->{NUMATTR} = undef;
 	$self->{ASSOCIATIONPOLICY} = undef;
-	$self->{ATTRIBUTES} = [];
+	$self->{GETTER} = undef;
+	$self->{SETTER} = undef;
 	bless($self, $class);
 	return $self;
 }
@@ -44,23 +44,24 @@ sub type {
 	return $self->{TYPE};
 }
 
-sub numattr {
-	my $self = shift;
-	if(@_) { $self->{NUMATTR} = shift; }
-	return $self->{NUMATTR};
-}
-
-sub attributes {
-	my $self = shift;
-	if(@_) { @{$self->{ATTRIBUTES}} = @_; }
-	return $self->{ATTRIBUTES};
-}
-
 sub associationPolicy {
 	my $self = shift;
-	if (@_) { $self->{ASSOCIATIONPOLICY} = shift; }
+	if(@_) { $self->{ASSOCIATIONPOLICY} = shift; }
 	return $self->{ASSOCIATIONPOLICY};
 }
+
+sub getter {
+	my $self = shift;
+	if(@_) { $self->{GETTER} = shift; }
+	return $self->{GETTER};
+}
+
+sub setter {
+	my $self = shift;
+	if(@_) { $self->{SETTER} = shift; }
+	return $self->{SETTER};
+}
+
 
 ##### #
 # END #

--- a/bin/logos.pl
+++ b/bin/logos.pl
@@ -576,19 +576,19 @@ foreach my $line (@lines) {
 			my $numattr = 0;
 
 			foreach(@attributes) {
-				if($_ =~ /assign/) {
-					$assign = 1;
-				} elsif($_ =~ /retain/) {
-					$retain = 1;
-				} elsif($_ =~ /copy/) {
-					$copy = 1;
-				} elsif($_ =~ /nonatomic/) {
-					$nonatomic = 1;
-				} elsif($_ =~ /getter=(\w+)/) {
+				if($_ =~ /getter=(\w+)/) {
 					$getter = $1;
 				} elsif($_ =~ /setter=(\w+:)/) {
 					$setter = $1;
-				} elsif($_ =~ /readwrite|readonly/) {
+				} elsif($_ eq "assign" || $_ eq "unsafe_unretained") {
+					$assign = 1;
+				} elsif($_ eq "retain" || $_ eq "strong") {
+					$retain = 1;
+				} elsif($_ eq "copy") {
+					$copy = 1;
+				} elsif($_ eq "nonatomic") {
+					$nonatomic = 1;
+				} elsif($_ =~ /readwrite|readonly|weak/) {
 					fileError($lineno, "property attribute '".$_."' not supported.");
 				} else {
 					fileError($lineno, "unknown property attribute '".$_."'.");


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Rewrites %property so its attributes are parsed only once in logos.pl and the "backend" uses the sigil name generator as well as aligning its methods to the rest of the directives (`getters_setters` -> `definitions`). The code generator wraps the objects into NSValues instead of supporting a subset of types with specific APIs from NSNumber and NSValue.

Does this close any currently open issues?
------------------------------------------
#243


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** macOS Sierra

**Platform:** N/A

**Target Platform:** N/A

**Toolchain Version:** N/A

**SDK Version:** N/A
