### PR TITLE
Use dm.pl when possible on iOS

### DIFF
--- a/makefiles/platform/Darwin-arm.mk
+++ b/makefiles/platform/Darwin-arm.mk
@@ -3,7 +3,12 @@ _THEOS_PLATFORM_LOADED := 1
 THEOS_PLATFORM_NAME := iphone
 
 _THEOS_PLATFORM_DEFAULT_TARGET := iphone
-_THEOS_PLATFORM_DPKG_DEB := dpkg-deb
+_THEOS_PLATFORM_DPKG_DEB := $(shell \
+	PATH=$$PATH:$(THEOS_BIN_PATH); \
+	DM=$$(which dm.pl); \
+	[ ! -z "$${DM}" ] && $(PERL) -MIO::Compress::Lzma -MIO::Compress::Gzip -MIO::Compress::Bzip2 -MIO::Compress::Xz -e 'exit 0' \
+		&& echo $$DM || echo dpkg-deb \
+	)
 _THEOS_PLATFORM_DU_EXCLUDE := --exclude
 _THEOS_PLATFORM_MD5SUM := md5sum
 _THEOS_PLATFORM_LIPO = lipo

--- a/makefiles/platform/Darwin-arm.mk
+++ b/makefiles/platform/Darwin-arm.mk
@@ -6,7 +6,7 @@ _THEOS_PLATFORM_DEFAULT_TARGET := iphone
 _THEOS_PLATFORM_DPKG_DEB := $(shell \
 	PATH=$$PATH:$(THEOS_BIN_PATH); \
 	DM=$$(which dm.pl); \
-	[ ! -z "$${DM}" ] && $(PERL) -MIO::Compress::Lzma -MIO::Compress::Gzip -MIO::Compress::Bzip2 -MIO::Compress::Xz -e 'exit 0' \
+	[ ! -z "$${DM}" ] && ($(PERL) -MIO::Compress::Lzma -e '1' 2>/dev/null) \
 		&& echo $$DM || echo dpkg-deb \
 	)
 _THEOS_PLATFORM_DU_EXCLUDE := --exclude

--- a/makefiles/platform/Darwin-arm.mk
+++ b/makefiles/platform/Darwin-arm.mk
@@ -6,6 +6,7 @@ _THEOS_PLATFORM_DEFAULT_TARGET := iphone
 _THEOS_PLATFORM_DPKG_DEB := $(shell \
 	PATH=$$PATH:$(THEOS_BIN_PATH); \
 	DM=$$(which dm.pl); \
+	[ -z "$${DM}" -a -f "$(THEOS_BIN_PATH)/dm.pl" ] && DM="$(THEOS_BIN_PATH)/dm.pl"; \
 	[ ! -z "$${DM}" ] && ($(PERL) -MIO::Compress::Lzma -e '1' 2>/dev/null) \
 		&& echo $$DM || echo dpkg-deb \
 	)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Changes Darwin-arm to use dm.pl when it is present and perl supports LZMA

Does this close any currently open issues?
------------------------------------------
no

Any other comments?
-------------------
With the patched bash this should be enough to make theos work on Electra

Where has this been tested?
---------------------------
**Operating System:** iOS, macOS

**Target Platform:** iphone
