### PR TITLE
Don't generate obj dir in the project's root directory

### DIFF
--- a/makefiles/rules.mk
+++ b/makefiles/rules.mk
@@ -34,7 +34,7 @@ $(THEOS_BUILD_DIR):
 endif
 
 $(THEOS_OBJ_DIR):
-	@cd $(_THEOS_LOCAL_DATA_DIR); mkdir -p $(THEOS_OBJ_DIR_NAME)
+	@mkdir -p $@
 
 $(THEOS_OBJ_DIR)/.stamp: $(THEOS_OBJ_DIR)
 	@mkdir -p $(dir $@); touch $@

--- a/makefiles/rules.mk
+++ b/makefiles/rules.mk
@@ -34,7 +34,7 @@ $(THEOS_BUILD_DIR):
 endif
 
 $(THEOS_OBJ_DIR):
-	@cd $(THEOS_BUILD_DIR); mkdir -p $(THEOS_OBJ_DIR_NAME)
+	@cd $(_THEOS_LOCAL_DATA_DIR); mkdir -p $(THEOS_OBJ_DIR_NAME)
 
 $(THEOS_OBJ_DIR)/.stamp: $(THEOS_OBJ_DIR)
 	@mkdir -p $(dir $@); touch $@


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
This prevents Theos from generating an empty obj dir in the project's root directory

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** macOS High Sierra 10.13.6 (17G65)

**Platform:** macOS

**Target Platform:** iOS

**Toolchain Version:** Xcode 10.0

**SDK Version:** iOS 12.0
