### PR TITLE
Add support for Xcode 10.2

### DIFF
--- a/makefiles/targets/_common/darwin_head.mk
+++ b/makefiles/targets/_common/darwin_head.mk
@@ -73,8 +73,8 @@ TARGET_LIBTOOL ?= $(call __invocation,libtool)
 TARGET_STRIP_FLAGS ?= -x
 
 ifeq ($(TARGET_DSYMUTIL),)
-ifeq ($(call __executable,$(call __invocation,llvm-dsymutil)),$(_THEOS_TRUE))
-	TARGET_DSYMUTIL = $(call __invocation,llvm-dsymutil)
+ifeq ($(call __executable,$(call __invocation,dsymutil)),$(_THEOS_TRUE))
+	TARGET_DSYMUTIL = $(call __invocation,dsymutil)
 else ifeq ($(call __executable,dsymutil),$(_THEOS_TRUE))
 	TARGET_DSYMUTIL = dsymutil
 endif


### PR DESCRIPTION
By using `dsymutil` instead of `llvm-dsymutil`, theos works with Xcode 10.2


What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes compiling projects with Xcode 10.2

Does this close any currently open issues?
------------------------------------------
closes #391 

Any relevant logs, error output, etc?
-------------------------------------
`xcrun: error: unable to find utility "llvm-dsymutil", not a developer tool or in PATH`

Where has this been tested?
---------------------------
**Operating System:** macOS Mojave 10.14.4

**Platform:** macOS

**Target Platform:** iOS

**Toolchain Version:** Xcode 10.2

**SDK Version:** 12.1