### PR TITLE
Fix tweaks on AppleTV

### DIFF
--- a/makefiles/targets/Darwin/appletv.mk
+++ b/makefiles/targets/Darwin/appletv.mk
@@ -11,6 +11,7 @@ _THEOS_DARWIN_CAN_USE_MODULES := $(_THEOS_TRUE)
 NEUTRAL_ARCH := arm64
 
 _THEOS_TARGET_DEFAULT_OS_DEPLOYMENT_VERSION := 9.0
+_THEOS_TARGET_LOGOS_DEFAULT_GENERATOR := internal
 
 include $(THEOS_MAKE_PATH)/targets/_common/darwin_head.mk
 include $(THEOS_MAKE_PATH)/targets/_common/darwin_tail.mk


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Modern AppleTV jailbreaks (>= AppleTV 4) by nitoTV haven't and never will (by his own admission) include CydiaSubstrate.framework. The default generator of MobileSubstrate links CydiaSubstrate.tbd to any tweak compiled for AppleTV, and this causes tweaks to not function, as they can't find the dynamically linked framework that isn't present on the device.

Does this close any currently open issues?
------------------------------------------
No, but would resolve a closed one. https://github.com/theos/theos/issues/400

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
While @kirb stated that he discussed it with nitotv and was told it was missing by mistake, multiple jailbreak updates have been released since and the framework is still not included. This, and him telling me himself it isn't meant to be there, leads me to believe it will never be fixed on the jailbreak's end. This PR fixes the issue and actually allows for tweaks built with upstream theos to work.

Where has this been tested?
---------------------------
**Operating System:** MacOS 10.13.6 & 10.15 beta 8

**Platform:** Darwin

**Target Platform:** tvOS

**Toolchain Version:** XCode 10.1, 11 beta 5

**SDK Version:** 10.1, 11.3, 12.4
