### PR TITLE
Use dysmutil as first choice

### DIFF
--- a/makefiles/targets/_common/darwin_head.mk
+++ b/makefiles/targets/_common/darwin_head.mk
@@ -73,10 +73,10 @@ TARGET_LIBTOOL ?= $(call __invocation,libtool)
 TARGET_STRIP_FLAGS ?= -x
 
 ifeq ($(TARGET_DSYMUTIL),)
-ifeq ($(call __executable,$(call __invocation,llvm-dsymutil)),$(_THEOS_TRUE))
-	TARGET_DSYMUTIL = $(call __invocation,llvm-dsymutil)
-else ifeq ($(call __executable,$(call __invocation,dsymutil)),$(_THEOS_TRUE))
+ifeq ($(call __executable,$(call __invocation,dsymutil)),$(_THEOS_TRUE))
 	TARGET_DSYMUTIL = $(call __invocation,dsymutil)
+else ifeq ($(call __executable,$(call __invocation,llvm-dsymutil)),$(_THEOS_TRUE))
+	TARGET_DSYMUTIL = $(call __invocation,llvm-dsymutil)
 endif
 endif
 


### PR DESCRIPTION
fix #434. use dysmutil as first choice, as llvm-dsymutil can be older… and buggy.

What does this implement/fix? Explain your changes.
---------------------------------------------------
llvm-dsymutil can be old and buggy, and theos currently prefer llvm-dsymutil over dsymutil

Does this close any currently open issues?
------------------------------------------
#434 

use dsymutil to fix warning `line table paramters mismatch. Cannot emit.` introduced by llvm-dsymutil for deploy target > 8.0, details please refer #434 

dsymutil found by xcrun is inside Xcode path, rather than /usr/local/bin, and is the latest
```
(printf "\e[0;3%im==> \e[1;39m%s…\e[m\n" 4 "Generating debug symbols for MyTweak"); set -o pipefail; (/Applic
ations/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil "./.theos/obj/debug/arm64/MyTweak")                                      
==> Generating debug symbols for MyTweak…  
==> Merging tool MyTweak…                                                                                    
==> Signing MyTweak…
```
