### PR TITLE
Add xcodeproj support

### DIFF
--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -44,7 +44,7 @@ endif
 ifeq ($(_THEOS_INTERNAL_TRUE_PATH),)
 _THEOS_RELATIVE_MAKE_PATH := $(dir $(lastword $(MAKEFILE_LIST)))
 _THEOS_INTERNAL_TRUE_PATH := $(call __clean_pwd,$(_THEOS_RELATIVE_MAKE_PATH)/..)
-ifneq ($(words $(_THEOS_INTERNAL_TRUE_PATH)),1) # It's a hack, but it works.
+ifneq ($(words $(_THEOS_INTERNAL_TRUE_PATH)),1) # a hack, but it works.
 $(shell unlink /tmp/theos &> /dev/null; ln -Ffs "$(_THEOS_INTERNAL_TRUE_PATH)" /tmp/theos)
 _THEOS_INTERNAL_TRUE_PATH := /tmp/theos
 endif

--- a/makefiles/instance/xcodeproj.mk
+++ b/makefiles/instance/xcodeproj.mk
@@ -1,0 +1,68 @@
+ifeq ($(_THEOS_RULES_LOADED),)
+include $(THEOS_MAKE_PATH)/rules.mk
+endif
+
+.PHONY: internal-xcodeproj-all_ internal-xcodeproj-stage_ internal-xcodeproj-compile
+
+ifeq ($(_THEOS_MAKE_PARALLEL_BUILDING), no)
+internal-xcodeproj-all_:: internal-xcodeproj-compile
+else
+internal-xcodeproj-all_::
+	$(ECHO_MAKE)$(MAKE) -f $(_THEOS_PROJECT_MAKEFILE_NAME) $(_THEOS_MAKEFLAGS) \
+		internal-xcodeproj-compile \
+		_THEOS_CURRENT_TYPE=$(_THEOS_CURRENT_TYPE) THEOS_CURRENT_INSTANCE=$(THEOS_CURRENT_INSTANCE) _THEOS_CURRENT_OPERATION=compile \
+		THEOS_BUILD_DIR="$(THEOS_BUILD_DIR)" _THEOS_MAKE_PARALLEL=yes
+endif
+
+ALL_XCODEFLAGS = $(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,XCODEFLAGS)
+ALL_XCODEOPTS = $(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,XCODEOPTS)
+
+ifneq ($(TARGET_XCPRETTY),)
+ifneq ($(_THEOS_VERBOSE),$(_THEOS_TRUE))
+	_THEOS_XCODE_XCPRETTY = | $(TARGET_XCPRETTY)
+endif
+endif
+
+ifeq ($(findstring DEBUG,$(THEOS_SCHEMA)),)
+	_THEOS_XCODE_BUILD_CONFIG = Release
+else
+	_THEOS_XCODE_BUILD_CONFIG = Debug
+endif
+
+_THEOS_XCODEBUILD_BEGIN = $(ECHO_NOTHING)set -e; $(TARGET_XCODEBUILD) -scheme '$(THEOS_CURRENT_INSTANCE)' -configuration $(_THEOS_XCODE_BUILD_CONFIG) -derivedDataPath $(THEOS_OBJ_DIR)
+_THEOS_XCODEBUILD_END = CODE_SIGNING_ALLOWED=NO DSTROOT=$(THEOS_OBJ_DIR)/install $(_THEOS_XCODE_XCPRETTY)$(ECHO_END)
+export EXPANDED_CODE_SIGN_IDENTITY =
+export EXPANDED_CODE_SIGN_IDENTITY_NAME =
+
+internal-xcodeproj-compile:
+	$(_THEOS_XCODEBUILD_BEGIN) \
+	$(ALL_XCODEOPTS) \
+	build install \
+	$(ALL_XCODEFLAGS) \
+	$(_THEOS_XCODEBUILD_END)
+ifeq ($(_THEOS_PACKAGE_FORMAT),deb)
+	$(ECHO_NOTHING)find $(THEOS_OBJ_DIR)/install -name 'libswift*.dylib' -delete$(ECHO_END)
+endif
+ifneq ($(_THEOS_CODESIGN_COMMANDLINE),)
+	$(ECHO_SIGNING)function process_exec { \
+		$(_THEOS_CODESIGN_COMMANDLINE) $$1; \
+	}; \
+	function process_bundle { \
+		process_exec $$1/$$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" $$1/Info.plist); \
+	}; \
+	export -f process_exec process_bundle; \
+# TODO: do this depth-first
+	find $(THEOS_OBJ_DIR)/install -name '*.dylib' -print0 | xargs -I{} -0 bash -c 'process_exec "$$@"' _ {}; \
+	find $(THEOS_OBJ_DIR)/install -name '*.framework' -print0 | xargs -I{} -0 bash -c 'process_bundle "$$@"' _ {}; \
+	find $(THEOS_OBJ_DIR)/install -name '*.appex' -print0 | xargs -I{} -0 bash -c 'process_bundle "$$@"' _ {}; \
+	find $(THEOS_OBJ_DIR)/install -name '*.app' -print0 | xargs -I{} -0 bash -c 'process_bundle "$$@"' _ {}; \
+	$(ECHO_END)
+endif
+
+ifneq ($($(THEOS_CURRENT_INSTANCE)_INSTALL),0)
+internal-xcodeproj-stage_::
+	$(ECHO_NOTHING)mkdir -p "$(THEOS_STAGING_DIR)"$(ECHO_END)
+	$(ECHO_NOTHING)rsync -a $(THEOS_OBJ_DIR)/install/ "$(THEOS_STAGING_DIR)" $(_THEOS_RSYNC_EXCLUDE_COMMANDLINE)$(ECHO_END)
+endif
+
+$(eval $(call __mod,instance/xcodeproj.mk))

--- a/makefiles/instance/xcodeproj.mk
+++ b/makefiles/instance/xcodeproj.mk
@@ -34,6 +34,7 @@ _THEOS_XCODEBUILD_END = CODE_SIGNING_ALLOWED=NO DSTROOT=$(THEOS_OBJ_DIR)/install
 export EXPANDED_CODE_SIGN_IDENTITY =
 export EXPANDED_CODE_SIGN_IDENTITY_NAME =
 
+# TODO: sign in a depth-first manner
 internal-xcodeproj-compile:
 	$(_THEOS_XCODEBUILD_BEGIN) \
 	$(ALL_XCODEOPTS) \
@@ -51,7 +52,6 @@ ifneq ($(_THEOS_CODESIGN_COMMANDLINE),)
 		process_exec $$1/$$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" $$1/Info.plist); \
 	}; \
 	export -f process_exec process_bundle; \
-# TODO: do this depth-first
 	find $(THEOS_OBJ_DIR)/install -name '*.dylib' -print0 | xargs -I{} -0 bash -c 'process_exec "$$@"' _ {}; \
 	find $(THEOS_OBJ_DIR)/install -name '*.framework' -print0 | xargs -I{} -0 bash -c 'process_bundle "$$@"' _ {}; \
 	find $(THEOS_OBJ_DIR)/install -name '*.appex' -print0 | xargs -I{} -0 bash -c 'process_bundle "$$@"' _ {}; \

--- a/makefiles/master/xcodeproj.mk
+++ b/makefiles/master/xcodeproj.mk
@@ -1,0 +1,19 @@
+XCODEPROJ_NAME := $(strip $(XCODEPROJ_NAME))
+
+ifeq ($(_THEOS_RULES_LOADED),)
+include $(THEOS_MAKE_PATH)/rules.mk
+endif
+
+internal-all:: $(XCODEPROJ_NAME:=.all.xcodeproj.variables);
+
+internal-stage:: $(XCODEPROJ_NAME:=.stage.xcodeproj.variables);
+
+XCODEPROJ_WITH_SUBPROJECTS = $(strip $(foreach xcodeproj,$(XCODEPROJ_NAME),$(patsubst %,$(xcodeproj),$(call __schema_var_all,$(xcodeproj)_,SUBPROJECTS))))
+ifneq ($(XCODEPROJ_WITH_SUBPROJECTS),)
+internal-clean:: $(XCODEPROJ_WITH_SUBPROJECTS:=.clean.xcodeproj.subprojects)
+endif
+
+$(XCODEPROJ_NAME):
+	$(ECHO_MAKE)$(MAKE) -f $(_THEOS_PROJECT_MAKEFILE_NAME) $(_THEOS_MAKEFLAGS) $@.all.xcodeproj.variables
+
+$(eval $(call __mod,master/xcodeproj.mk))

--- a/makefiles/targets/_common/darwin_head.mk
+++ b/makefiles/targets/_common/darwin_head.mk
@@ -69,6 +69,8 @@ TARGET_LIPO ?= $(call __invocation,lipo)
 TARGET_STRIP ?= $(call __invocation,strip)
 TARGET_CODESIGN_ALLOCATE ?= $(call __invocation,codesign_allocate)
 TARGET_LIBTOOL ?= $(call __invocation,libtool)
+TARGET_XCODEBUILD ?= $(call __invocation,xcodebuild)
+TARGET_XCPRETTY ?= $(call __invocation,xcpretty)
 
 TARGET_STRIP_FLAGS ?= -x
 

--- a/makefiles/xcodeproj.mk
+++ b/makefiles/xcodeproj.mk
@@ -1,0 +1,7 @@
+ifeq ($(THEOS_CURRENT_INSTANCE),)
+	include $(THEOS_MAKE_PATH)/master/xcodeproj.mk
+else
+	ifeq ($(_THEOS_CURRENT_TYPE),xcodeproj)
+		include $(THEOS_MAKE_PATH)/instance/xcodeproj.mk
+	endif
+endif


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds support for building Xcode projects while taking advantage of the rest of Theos' build system (eg. packaging, installation, subprojects). The primary use case is probably jailbroken apps. Sileo, Supercharge, and NewTerm all either use or have been tested with this branch.

Does this close any currently open issues?
------------------------------------------
Not that I know of

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
Nope

Any other comments?
-------------------
The one issue that I currently see is the fact that Xcode build failures don't propagate to the rest of Theos – i.e. subsequent tasks will continue without knowing that the build has failed. We should probably fix this before merging, which is why this is currently a draft PR.

Where has this been tested?
---------------------------
**Operating System:** macOS 10.14.6 (18G103)

**Platform:** macOS

**Target Platform:** iOS

**Toolchain Version:** Latest

**SDK Version:** Latest
