### PR TITLE
`make uninstall` should unload target processes

### DIFF
--- a/makefiles/master/aggregate.mk
+++ b/makefiles/master/aggregate.mk
@@ -5,10 +5,10 @@ endif
 SUBPROJECTS := $(strip $(call __schema_var_all,,SUBPROJECTS))
 ifneq ($(SUBPROJECTS),)
 internal-all internal-clean:: _OPERATION = $(subst internal-,,$@)
-internal-stage internal-after-install:: _OPERATION = $@
-internal-all internal-clean internal-stage internal-after-install:: _OPERATION_NAME = $(subst internal-,,$@)
+internal-stage internal-after-install internal-after-uninstall:: _OPERATION = $@
+internal-all internal-clean internal-stage internal-after-install internal-after-uninstall:: _OPERATION_NAME = $(subst internal-,,$@)
 
-internal-all internal-clean internal-stage internal-after-install::
+internal-all internal-clean internal-stage internal-after-install internal-after-uninstall::
 	+@abs_build_dir=$(_THEOS_ABSOLUTE_BUILD_DIR); \
 	for d in $(SUBPROJECTS); do \
 	  $(PRINT_FORMAT_MAKING) "Making $(_OPERATION_NAME) in $$d"; \

--- a/makefiles/package.mk
+++ b/makefiles/package.mk
@@ -138,6 +138,12 @@ internal-after-uninstall::
 -include $(THEOS_MAKE_PATH)/install/$(_THEOS_PACKAGE_FORMAT)_$(_THEOS_INSTALL_TYPE).mk
 $(eval $(call __mod,install/$(_THEOS_PACKAGE_FORMAT)_$(_THEOS_INSTALL_TYPE).mk))
 
+ifeq ($(INSTALL_TARGET_PROCESSES),)
+	@:
+else
+	$(ECHO_UNLOADING)install.exec "killall $(INSTALL_TARGET_PROCESSES) 2>/dev/null || true"$(ECHO_END)
+endif
+
 endif # _THEOS_PACKAGE_RULES_LOADED
 
 show:: internal-install-check

--- a/makefiles/package.mk
+++ b/makefiles/package.mk
@@ -134,6 +134,11 @@ internal-uninstall::
 	@:
 
 internal-after-uninstall::
+ifeq ($(INSTALL_TARGET_PROCESSES),)
+	@:
+else
+	$(ECHO_UNLOADING)install.exec "killall $(INSTALL_TARGET_PROCESSES) 2>/dev/null || true"$(ECHO_END)
+endif
 
 -include $(THEOS_MAKE_PATH)/install/$(_THEOS_PACKAGE_FORMAT)_$(_THEOS_INSTALL_TYPE).mk
 $(eval $(call __mod,install/$(_THEOS_PACKAGE_FORMAT)_$(_THEOS_INSTALL_TYPE).mk))

--- a/makefiles/package.mk
+++ b/makefiles/package.mk
@@ -143,12 +143,6 @@ endif
 -include $(THEOS_MAKE_PATH)/install/$(_THEOS_PACKAGE_FORMAT)_$(_THEOS_INSTALL_TYPE).mk
 $(eval $(call __mod,install/$(_THEOS_PACKAGE_FORMAT)_$(_THEOS_INSTALL_TYPE).mk))
 
-ifeq ($(INSTALL_TARGET_PROCESSES),)
-	@:
-else
-	$(ECHO_UNLOADING)install.exec "killall $(INSTALL_TARGET_PROCESSES) 2>/dev/null || true"$(ECHO_END)
-endif
-
 endif # _THEOS_PACKAGE_RULES_LOADED
 
 show:: internal-install-check


### PR DESCRIPTION
Is there an approach to this other than just copy-pasting the content of internal-after-install? Or is this fine? My `make` skills aren't very sharp