### PR TITLE
Remove $(SDKTARGET)- prefix name requirement for linux toolchain binaries

### DIFF
--- a/makefiles/targets/Linux/iphone.mk
+++ b/makefiles/targets/Linux/iphone.mk
@@ -11,7 +11,7 @@ SWIFTBINPATH ?= $(THEOS)/toolchain/swift/bin
 SDKBINPATH ?= $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin
 
 # Determine toolchain to use based on file existence.
-ifeq ($(SDKTARGET),)
+ifeq ($(SDKTARGETPREFIX),)
 ifeq ($(call __exists, $(SDKBINPATH)/armv7-apple-darwin11-ld),$(_THEOS_TRUE))
 SDKTARGETPREFIX ?= armv7-apple-darwin11-
 else ifeq ($(call __exists, $(SDKBINPATH)/arm64-apple-darwin14-ld),$(_THEOS_TRUE))

--- a/makefiles/targets/Linux/iphone.mk
+++ b/makefiles/targets/Linux/iphone.mk
@@ -17,7 +17,7 @@ SDKTARGETPREFIX ?= armv7-apple-darwin11-
 else ifeq ($(call __exists, $(SDKBINPATH)/arm64-apple-darwin14-ld),$(_THEOS_TRUE))
 SDKTARGETPREFIX ?= arm64-apple-darwin14-
 else
-SDKTARGETPREFIX ?=
+# toolchain has no prefix so we are responsible of supplying target triple to clang for cross compiling
 TARGET_OPTIONS ?= -target arm64-apple-darwin
 endif
 endif

--- a/makefiles/targets/Linux/iphone.mk
+++ b/makefiles/targets/Linux/iphone.mk
@@ -15,7 +15,7 @@ include $(THEOS_MAKE_PATH)/targets/_common/darwin_head.mk
 include $(THEOS_MAKE_PATH)/targets/_common/iphone.mk
 include $(THEOS_MAKE_PATH)/targets/_common/darwin_tail.mk
 
-TARGET_OPTIONS ?= -target apple-darwin
+TARGET_OPTIONS ?= -target arm64-apple-darwin
 _THEOS_TARGET_CFLAGS += $(TARGET_OPTIONS)
 _THEOS_TARGET_CCFLAGS += $(TARGET_OPTIONS)
 _THEOS_TARGET_LDFLAGS += $(TARGET_OPTIONS)

--- a/makefiles/targets/Linux/iphone.mk
+++ b/makefiles/targets/Linux/iphone.mk
@@ -7,20 +7,16 @@ _THEOS_TARGET_PLATFORM_SDK_NAME := iPhoneOS
 _THEOS_TARGET_PLATFORM_FLAG_NAME := iphoneos
 _THEOS_TARGET_PLATFORM_SWIFT_NAME := apple-ios
 
-# Determine toolchain to use based on file existence.
-ifeq ($(SDKTARGET),)
-ifeq ($(wildcard $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin/arm64-apple-darwin14-ld),)
-SDKTARGET ?= armv7-apple-darwin11
-else
-SDKTARGET ?= arm64-apple-darwin14
-endif
-endif
-
 SWIFTBINPATH ?= $(THEOS)/toolchain/swift/bin
 SDKBINPATH ?= $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin
-PREFIX := $(SDKBINPATH)/$(SDKTARGET)-
+PREFIX := $(SDKBINPATH)/
 
 include $(THEOS_MAKE_PATH)/targets/_common/darwin_head.mk
 include $(THEOS_MAKE_PATH)/targets/_common/iphone.mk
 include $(THEOS_MAKE_PATH)/targets/_common/darwin_tail.mk
+
+TARGET_OPTIONS ?= -target apple-darwin
+_THEOS_TARGET_CFLAGS += $(TARGET_OPTIONS)
+_THEOS_TARGET_CCFLAGS += $(TARGET_OPTIONS)
+_THEOS_TARGET_LDFLAGS += $(TARGET_OPTIONS)
 endif

--- a/makefiles/targets/Linux/iphone.mk
+++ b/makefiles/targets/Linux/iphone.mk
@@ -9,13 +9,25 @@ _THEOS_TARGET_PLATFORM_SWIFT_NAME := apple-ios
 
 SWIFTBINPATH ?= $(THEOS)/toolchain/swift/bin
 SDKBINPATH ?= $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin
-PREFIX := $(SDKBINPATH)/
+
+# Determine toolchain to use based on file existence.
+ifeq ($(SDKTARGET),)
+ifeq ($(call __exists, $(SDKBINPATH)/armv7-apple-darwin11-ld),$(_THEOS_TRUE))
+SDKTARGETPREFIX ?= armv7-apple-darwin11-
+else ifeq ($(call __exists, $(SDKBINPATH)/arm64-apple-darwin14-ld),$(_THEOS_TRUE))
+SDKTARGETPREFIX ?= arm64-apple-darwin14-
+else
+SDKTARGETPREFIX ?=
+TARGET_OPTIONS ?= -target arm64-apple-darwin
+endif
+endif
+
+PREFIX := $(SDKBINPATH)/$(SDKTARGETPREFIX)
 
 include $(THEOS_MAKE_PATH)/targets/_common/darwin_head.mk
 include $(THEOS_MAKE_PATH)/targets/_common/iphone.mk
 include $(THEOS_MAKE_PATH)/targets/_common/darwin_tail.mk
 
-TARGET_OPTIONS ?= -target arm64-apple-darwin
 _THEOS_TARGET_CFLAGS += $(TARGET_OPTIONS)
 _THEOS_TARGET_CCFLAGS += $(TARGET_OPTIONS)
 _THEOS_TARGET_LDFLAGS += $(TARGET_OPTIONS)

--- a/makefiles/targets/Linux/iphone.mk
+++ b/makefiles/targets/Linux/iphone.mk
@@ -11,24 +11,24 @@ SWIFTBINPATH ?= $(THEOS)/toolchain/swift/bin
 SDKBINPATH ?= $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin
 
 # Determine toolchain to use based on file existence.
-ifeq ($(SDKTARGETPREFIX),)
+ifeq ($(_THEOS_TARGET_SDK_BIN_PREFIX),)
 ifeq ($(call __exists, $(SDKBINPATH)/armv7-apple-darwin11-ld),$(_THEOS_TRUE))
-SDKTARGETPREFIX ?= armv7-apple-darwin11-
+_THEOS_TARGET_SDK_BIN_PREFIX ?= armv7-apple-darwin11-
 else ifeq ($(call __exists, $(SDKBINPATH)/arm64-apple-darwin14-ld),$(_THEOS_TRUE))
-SDKTARGETPREFIX ?= arm64-apple-darwin14-
+_THEOS_TARGET_SDK_BIN_PREFIX ?= arm64-apple-darwin14-
 else
 # toolchain has no prefix so we are responsible of supplying target triple to clang for cross compiling
-TARGET_OPTIONS ?= -target arm64-apple-darwin
+_THEOS_TARGET_TRIPLE_FLAG ?= -target arm64-apple-darwin
 endif
 endif
 
-PREFIX := $(SDKBINPATH)/$(SDKTARGETPREFIX)
+PREFIX := $(SDKBINPATH)/$(_THEOS_TARGET_SDK_BIN_PREFIX)
 
 include $(THEOS_MAKE_PATH)/targets/_common/darwin_head.mk
 include $(THEOS_MAKE_PATH)/targets/_common/iphone.mk
 include $(THEOS_MAKE_PATH)/targets/_common/darwin_tail.mk
 
-_THEOS_TARGET_CFLAGS += $(TARGET_OPTIONS)
-_THEOS_TARGET_CCFLAGS += $(TARGET_OPTIONS)
-_THEOS_TARGET_LDFLAGS += $(TARGET_OPTIONS)
+_THEOS_TARGET_CFLAGS += $(_THEOS_TARGET_TRIPLE_FLAG)
+_THEOS_TARGET_CCFLAGS += $(_THEOS_TARGET_TRIPLE_FLAG)
+_THEOS_TARGET_LDFLAGS += $(_THEOS_TARGET_TRIPLE_FLAG)
 endif


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Removes the need to have prefixes, such as `armv7-apple-darwin-` and `arm64-apple-darwin-` for the linux toolchains. With this change it should make sbingner's arm64e linux toolchain ([https://github.com/sbingner/llvm-project/releases/tag/v10.0.0-1](https://github.com/sbingner/llvm-project/releases/tag/v10.0.0-1)) "plug and play".

Does this close any currently open issues?
------------------------------------------
#482 

Any other comments?
-------------------
This is going to break backwards compatibility with old and current Kabir's linux toolchain which has those prefixes.


Where has this been tested?
---------------------------
**Operating System:**
- Windows 10 (Debian WSL)
- Debian

**Platform:**
- Linux

**Target Platform:**
- iPhone

**Toolchain Version:**
- [https://github.com/sbingner/llvm-project/releases/tag/v10.0.0-1](https://github.com/sbingner/llvm-project/releases/tag/v10.0.0-1)

**SDK Version:**
- 13.0 (Debian WSL)
- 11.2 (Debian)
