### PR TITLE
Fixed installing + uninstalling SIMBL tweaks via `make do`, `make install` and `make uninstall`.

### DIFF
--- a/bin/install.exec
+++ b/bin/install.exec
@@ -15,5 +15,5 @@ if [[ $TARGET_INSTALL_REMOTE == 1 ]]; then
 
 	exec ${args[@]}
 else
-	exec su -c "$@"
+	exec bash -c "$@"
 fi

--- a/makefiles/install/pkg_local.mk
+++ b/makefiles/install/pkg_local.mk
@@ -2,4 +2,4 @@ internal-install:: internal-install-check
 	$(ECHO_INSTALLING)install.exec "$(_THEOS_SUDO_COMMAND) installer -pkg \"$(_THEOS_PACKAGE_LAST_FILENAME)\" -target /"$(ECHO_END)
 
 internal-uninstall::
-	$(ECHO_NOTHING)install.exec "pkgutil --files \"$(THEOS_PACKAGE_NAME)\" | tail -r | sed 's/^/\//' | $(_THEOS_SUDO_COMMAND) xargs rm -d; $(_THEOS_SUDO_COMMAND) pkgutil --forget \"$(THEOS_PACKAGE_NAME)\""$(ECHO_END)
+	$(ECHO_NOTHING)install.exec "pkgutil --files \"$(THEOS_PACKAGE_NAME)\" | tail -r | sed 's/^/\//' | tr '\n' '\0' | $(_THEOS_SUDO_COMMAND) xargs -0 rm -d 2> /dev/null; $(_THEOS_SUDO_COMMAND) pkgutil --forget \"$(THEOS_PACKAGE_NAME)\""$(ECHO_END)

--- a/makefiles/instance/simbltweak.mk
+++ b/makefiles/instance/simbltweak.mk
@@ -9,7 +9,7 @@ _THEOS_INTERNAL_LDFLAGS += -dynamiclib
 # Bundle Setup
 LOCAL_INSTALL_PATH ?= $(strip $($(THEOS_CURRENT_INSTANCE)_INSTALL_PATH))
 ifeq ($(LOCAL_INSTALL_PATH),)
-	LOCAL_INSTALL_PATH = /Library/Application Support/SIMBL/Plugins
+	LOCAL_INSTALL_PATH = /Library/Application Support/MacEnhance/Plugins
 endif
 
 ifeq ($($(THEOS_CURRENT_INSTANCE)_BUNDLE_NAME),)


### PR DESCRIPTION
Fixed installing + uninstalling SIMBL tweaks via `make do`, `make install` and `make uninstall`.

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixed installing + uninstalling SIMBL tweaks via `make do`, `make install` and `make uninstall`.
- Updated default install path to MacForge's plugin directory
- Fixed up uninstall command to not break when encountering spaces in file paths (and silenced the `rm -d` output)
- Fixed the local install command in `bin/install.exec` (thanks @kirb).

Does this close any currently open issues?
------------------------------------------
- #514 
- #515 


Any relevant logs, error output, etc?
-------------------------------------
Nope.

Any other comments?
-------------------
mySIMBL is pretty old now, and MacForge has become the standard injection program for macOS. IMO it's time to retire mySIMBL support in favour of MacForge support, which is exactly what this PR does.

Where has this been tested?
---------------------------
**Operating System:** macOS 10.15.4

**Platform:** macOS

**Target Platform:** macOS

**Toolchain Version:** …

**SDK Version:** 10.15.4
