### PR TITLE
Improve xcodeproj debugging

### DIFF
--- a/makefiles/instance/xcodeproj.mk
+++ b/makefiles/instance/xcodeproj.mk
@@ -14,8 +14,19 @@ internal-xcodeproj-all_::
 		THEOS_BUILD_DIR="$(THEOS_BUILD_DIR)" _THEOS_MAKE_PARALLEL=yes
 endif
 
-ALL_XCODEFLAGS = $(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,XCODEFLAGS)
-ALL_XCODEOPTS = $(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,XCODEOPTS)
+ALL_XCODEFLAGS = $(_THEOS_INTERNAL_XCODEFLAGS) $(ADDITIONAL_XCODEFLAGS) $(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,XCODEFLAGS) $(call __schema_var_all,,XCODEFLAGS)
+ALL_XCODEOPTS = $(_THEOS_INTERNAL_XCODEOPTS) $(ADDITIONAL_XCODEOPTS) $(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,XCODEOPTS) $(call __schema_var_all,,XCODEOPTS)
+
+# Xcode strips even debug builds, which is an issue when using lldb because it's unable to 
+# locate the local unstripped copy since it isn't aware of our custom derivedDataPath. While 
+# that underlying issue still needs to be resolved to allow debugging release builds, the 
+# following is a more immediate solution until we get around to solving that – which we could
+# do by, for example, writing a DBGShellCommands script or using DBGFileMappedPaths.
+ifeq ($(SHOULD_STRIP),$(_THEOS_TRUE))
+_THEOS_INTERNAL_XCODEFLAGS += STRIP_INSTALLED_PRODUCT=YES
+else
+_THEOS_INTERNAL_XCODEFLAGS += STRIP_INSTALLED_PRODUCT=NO
+endif
 
 ifneq ($(TARGET_XCPRETTY),)
 ifneq ($(_THEOS_VERBOSE),$(_THEOS_TRUE))

--- a/makefiles/instance/xcodeproj.mk
+++ b/makefiles/instance/xcodeproj.mk
@@ -22,11 +22,7 @@ ALL_XCODEOPTS = $(_THEOS_INTERNAL_XCODEOPTS) $(ADDITIONAL_XCODEOPTS) $(call __sc
 # that underlying issue still needs to be resolved to allow debugging release builds, the 
 # following is a more immediate solution until we get around to solving that – which we could
 # do by, for example, writing a DBGShellCommands script or using DBGFileMappedPaths.
-ifeq ($(SHOULD_STRIP),$(_THEOS_TRUE))
-_THEOS_INTERNAL_XCODEFLAGS += STRIP_INSTALLED_PRODUCT=YES
-else
-_THEOS_INTERNAL_XCODEFLAGS += STRIP_INSTALLED_PRODUCT=NO
-endif
+_THEOS_INTERNAL_XCODEFLAGS += STRIP_INSTALLED_PRODUCT=$(if $(SHOULD_STRIP),YES,NO)
 
 ifneq ($(TARGET_XCPRETTY),)
 ifneq ($(_THEOS_VERBOSE),$(_THEOS_TRUE))


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR allows lldb to correctly symbolicate xcodeproj-based binaries while debugging. This is achieved by making Xcode not strip DWARF info during debug builds, bringing it closer to how Theos normally behaves. It's usually alright for Xcode to strip this info during installation because it retains an un-stripped copy on the host, which lldb can refer to during symbolication. Since we provide a custom `derivedDataPath` while building, however, lldb is unable to locate the unstripped copy as it doesn't know about the custom path.

Does this close any currently open issues?
------------------------------------------
Nope


Any relevant logs, error output, etc?
-------------------------------------
Nope

Any other comments?
-------------------
We should probably switch to Xcode's behaviour in the future (even for non-xcodeproj projects). This will reduce the size of debug packages and also allow symbolicating release binaries. In order to achieve this we'll need to create a custom `DBGShellCommands` script to ensure that lldb can correctly locate the required dSYM/DWARF info for the binary.

Where has this been tested?
---------------------------
**Operating System**: macOS 10.14.6 (18G5033)

**Platform**: macOS

**Target Platform**: iOS

**Toolchain Version**: Xcode 11.2.1 (11B53)

**SDK Version**: iOS 13.2
