### PR TITLE
Fix TARGET_OS_IPHONE not being defined in Prefix.pch (Resolves #552)

### DIFF
--- a/Prefix.pch
+++ b/Prefix.pch
@@ -10,6 +10,10 @@
 // has already been removed for other platforms, such as macOS and tvOS, and is not used
 // at all for Swift files.
 
+#if __has_include(<TargetConditionals.h>)
+#include <TargetConditionals.h>
+#endif
+
 #ifdef DEBUG
 	#define __DEBUG__
 #endif


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
TargetConditionals.h needs to be included in Prefix.pch, otherwise TARGET_OS_IPHONE might not be defined which causes the later checks to fail.

Does this close any currently open issues?
------------------------------------------
Yes, #552 


Any relevant logs, error output, etc?
-------------------------------------
See the issue for more information

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Operating System:** macOS 11.4

**Platform:** macOS

**Target Platform:** iOS

**Toolchain Version:** Xcode 12.5

**SDK Version:** iPhoneOS13.0
