### PR TITLE
Prefix.pch: Don't import TargetConditionals.h unless neccessary, correctly undefine _THEOS_IS_SIMULATOR

### DIFF
--- a/Prefix.pch
+++ b/Prefix.pch
@@ -19,22 +19,12 @@
 		#if __has_include(<TargetConditionals.h>)
 			#import <TargetConditionals.h>
 		#endif
-		#ifdef TARGET_OS_IPHONE
-			#ifdef TARGET_OS_SIMULATOR
-				#define _THEOS_IS_SIMULATOR TARGET_OS_SIMULATOR
-			#else
-				#define _THEOS_IS_SIMULATOR TARGET_IPHONE_SIMULATOR
-			#endif
-
-			#if (TARGET_OS_IPHONE || _THEOS_IS_SIMULATOR)
-				#import <theos/BackwardsCompat.h>
-				#import <Foundation/Foundation.h>
-				#import <UIKit/UIKit.h>
-				#import <theos/IOSMacros.h>
-				#import <HBLog.h>
-			#endif
-
-			#undef _THEOS_IS_SIMULATOR
+		#if TARGET_OS_IPHONE
+			#import <theos/BackwardsCompat.h>
+			#import <Foundation/Foundation.h>
+			#import <UIKit/UIKit.h>
+			#import <theos/IOSMacros.h>
+			#import <HBLog.h>
 		#endif
 	#endif
 #endif

--- a/Prefix.pch
+++ b/Prefix.pch
@@ -10,30 +10,31 @@
 // has already been removed for other platforms, such as macOS and tvOS, and is not used
 // at all for Swift files.
 
-#if __has_include(<TargetConditionals.h>)
-#include <TargetConditionals.h>
-#endif
-
 #ifdef DEBUG
 	#define __DEBUG__
 #endif
 
-#ifdef __OBJC__
-	#ifdef TARGET_OS_IPHONE
-		#ifdef TARGET_OS_SIMULATOR
-			#define _THEOS_IS_SIMULATOR TARGET_OS_SIMULATOR
-		#else
-			#define _THEOS_IS_SIMULATOR TARGET_IPHONE_SIMULATOR
+#if !defined(__IPHONE_14_0) && !defined(THEOS_LEAN_AND_MEAN)
+	#ifdef __OBJC__
+		#if __has_include(<TargetConditionals.h>)
+			#import <TargetConditionals.h>
 		#endif
+		#ifdef TARGET_OS_IPHONE
+			#ifdef TARGET_OS_SIMULATOR
+				#define _THEOS_IS_SIMULATOR TARGET_OS_SIMULATOR
+			#else
+				#define _THEOS_IS_SIMULATOR TARGET_IPHONE_SIMULATOR
+			#endif
 
-		#if (TARGET_OS_IPHONE || _THEOS_IS_SIMULATOR) && !defined(__IPHONE_14_0) && !defined(THEOS_LEAN_AND_MEAN)
-			#import <theos/BackwardsCompat.h>
-			#import <Foundation/Foundation.h>
-			#import <UIKit/UIKit.h>
-			#import <theos/IOSMacros.h>
-			#import <HBLog.h>
+			#if (TARGET_OS_IPHONE || _THEOS_IS_SIMULATOR)
+				#import <theos/BackwardsCompat.h>
+				#import <Foundation/Foundation.h>
+				#import <UIKit/UIKit.h>
+				#import <theos/IOSMacros.h>
+				#import <HBLog.h>
+			#endif
+
+			#undef _THEOS_IS_SIMULATOR
 		#endif
-
-		#undef _THEOS_IS_IOS
 	#endif
 #endif


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adresses concerns about my previous PR #596 (see comments)

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** macOS

**Target Platform:** iOS

**Toolchain Version:** Xcode 12.5

**SDK Version:** iPhoneOS13.0
