### PR TITLE
Theos project linter/sanity checker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "vendor/templates"]
 	path = vendor/templates
 	url = https://github.com/theos/templates.git
+[submodule "vendor/theos-lint"]
+	path = vendor/theos-lint
+	url = https://github.com/KritantaDev/tl

--- a/bin/theos-lint
+++ b/bin/theos-lint
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+command -v python3 > /dev/null && python3 $THEOS/vendor/theos-lint/main.py

--- a/makefiles/package.mk
+++ b/makefiles/package.mk
@@ -11,7 +11,7 @@ ifeq ($(_THEOS_FINAL_PACKAGE),$(_THEOS_TRUE))
 	$(ECHO_NOTHING)find $(THEOS_STAGING_DIR) \( -name \*.plist -or -name \*.strings \) -exec plutil -convert binary1 {} \;$(ECHO_END)
 endif
 internal-package-check::
-	@:
+	$(ECHO_NOTHING)$(THEOS)/bin/theos-lint$(ECHO_END)
 
 # __THEOS_LAST_PACKAGE_FILENAME is to be set by a rule variable in the package format makefile.
 after-package::


### PR DESCRIPTION
What does this implement/fix? 
---------------------------------------------------
This fork implements a small, expandable sanity checker into Theos.

It quickly processes project/subproject files and scans for any issues that may/will cause problems building. 

It aims to act as a bandaid for errors from outside applications which cant be parsed and explained properly by theos.

It also aims to save build time by finding errors that wouldn't have arisen until later in the build process, or even errors only appearing on-device/during Cydia installation.

Does this close any currently open issues?
------------------------------------------
This was started as a response to issue #601, logos issue [#71](https://github.com/theos/logos/issues/71), and the abundance of other issues and questions related to unclear error messages or problems theos allows.

Any other comments?
-------------------
Included in a reply to this comment.

Testing
---------------------------
**Platforms tested on thus far:** 
* MacOS

**Projects tested on so far:** 
* Two test projects included in the https://github.com/kritantadev/tl repo

