### PR TITLE
Use git URLs instead of HTTPS URLs to work around unsupported TLS version on iOS 5.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "vendor/dm.pl"]
 	path = vendor/dm.pl
-	url = https://github.com/theos/dm.pl.git
+	url = git://github.com/theos/dm.pl.git
 [submodule "vendor/include"]
 	path = vendor/include
-	url = https://github.com/theos/headers.git
+	url = git://github.com/theos/headers.git
 [submodule "vendor/lib"]
 	path = vendor/lib
-	url = https://github.com/theos/lib.git
+	url = git://github.com/theos/lib.git
 [submodule "vendor/logos"]
 	path = vendor/logos
-	url = https://github.com/theos/logos.git
+	url = git://github.com/theos/logos.git
 [submodule "vendor/nic"]
 	path = vendor/nic
-	url = https://github.com/theos/nic.git
+	url = git://github.com/theos/nic.git
 [submodule "vendor/templates"]
 	path = vendor/templates
-	url = https://github.com/theos/templates.git
+	url = git://github.com/theos/templates.git


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Use git URLs instead of HTTPS URLs to work around unsupported TLS version on iOS 5.1.1

GitHub won't accept requests if the TLS version is too low.
If you try to clone theos using https on an old iOS version such as iOS 5.1.1 which doesn't support modern TLS, it gets stuck when it tries to clone the submodules:

e.g. An example of the error when you try to clone using HTTPS on iOS 5.1.1
```
fatal: unable to access 'https://github.com/theos/theos.git/': error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version
```

This change updates the submodules to use `git://` URLs rather than `https://` URLs, which allows the following to just work on iOS 5.1.1:

```
 git clone --recursive git://github.com/theos/theos.git $THEOS
```

The wiki will also need to be updated to change git clone command to the above if this PR is accepted.


Where has this been tested?
---------------------------
**Operating System:** iOS 5.1.1