### PR TITLE
Fix `install.exec` locally for iOS/macOS

### DIFF
--- a/bin/install.exec
+++ b/bin/install.exec
@@ -15,5 +15,5 @@ if [[ $TARGET_INSTALL_REMOTE == 1 ]]; then
 
 	exec ${args[@]}
 else
-	exec su -c "$@"
+	exec su root -c "$@"
 fi


### PR DESCRIPTION
Adds compatibility with BSD su, which macOS and Procursus both take advantage of. Continues to work on Linux su.