### PR TITLE
Fix orion git submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 	url = https://github.com/theos/swift-support.git
 [submodule "vendor/orion"]
 	path = vendor/orion
-	url = https://github.com/theos/orion
+	url = https://github.com/theos/orion.git


### PR DESCRIPTION
Without this, `git submodule update --init --recursive` fails with `fatal: not a git repository: ../../.git/modules/vendor/orion`