### PR TITLE
Prompt user if missing fakeroot and quiet make's removal of intermediates 

### DIFF
--- a/bin/fakeroot.sh
+++ b/bin/fakeroot.sh
@@ -28,18 +28,15 @@ fi
 
 if [[ "$USER" == "root" ]]; then
 	fakeroot=""
-elif type fauxsu &> /dev/null; then
-	fakeroot="fauxsu -p $persistence -- "
-elif type fakeroot-ng &> /dev/null; then
-	fakeroot="fakeroot-ng -p $persistence -- "
 elif type fakeroot &> /dev/null; then
 	fakeroot="fakeroot -i $persistence -s $persistence -- "
+elif type fakeroot-ng &> /dev/null; then
+	fakeroot="fakeroot-ng -p $persistence -- "
+elif type fauxsu &> /dev/null; then
+	fakeroot="fauxsu -p $persistence -- "
 else
-	if [[ $required -eq 1 ]]; then
-		fakeroot=""
-	else
-		fakeroot=": "
-	fi
+	echo "ERROR: fakeroot.sh: Please install either fakeroot, fakeroot-ng, or fauxsu."
+	exit 1
 fi
 
 #echo $fakeroot $cmd

--- a/bin/fakeroot.sh
+++ b/bin/fakeroot.sh
@@ -35,8 +35,13 @@ elif type fakeroot-ng &> /dev/null; then
 elif type fauxsu &> /dev/null; then
 	fakeroot="fauxsu -p $persistence -- "
 else
-	echo "ERROR: fakeroot.sh: Please install either fakeroot, fakeroot-ng, or fauxsu."
-	exit 1
+	if [[ $required -eq 1 ]]; then
+		fakeroot=""
+	else
+		fakeroot=": "
+		printf "\e[0;36m==> \e[1;36mNotice:\e[m %s\n" \
+			"fakeroot is not installed (and may not be available for your OS), so the requested fakeroot operation is being ignored."
+	fi
 fi
 
 #echo $fakeroot $cmd

--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -260,6 +260,7 @@ $(THEOS_OBJ_DIR)/%.x.m: %.x
 $(THEOS_OBJ_DIR)/%.x.$(_THEOS_OBJ_FILE_TAG).o: %.x $(THEOS_OBJ_DIR)/%.x.m
 	$(ECHO_NOTHING)mkdir -p $(dir $@)$(ECHO_END)
 	$(ECHO_COMPILING)$(ECHO_UNBUFFERED)$(TARGET_CXX) -x objective-c -c -I"$(call __clean_pwd,$(dir $<))" $(_THEOS_INTERNAL_IFLAGS_C) $(ALL_DEPFLAGS) $(ALL_CFLAGS) $(ALL_OBJCFLAGS) $(THEOS_OBJ_DIR)/$<.m -o $@$(ECHO_END)
+	$(ECHO_NOTHING)rm $(THEOS_OBJ_DIR)/$<.m$(ECHO_END)
 
 $(THEOS_OBJ_DIR)/%.xm.mm: %.xm
 	$(ECHO_NOTHING)mkdir -p $(dir $@)$(ECHO_END)
@@ -268,6 +269,7 @@ $(THEOS_OBJ_DIR)/%.xm.mm: %.xm
 $(THEOS_OBJ_DIR)/%.xm.$(_THEOS_OBJ_FILE_TAG).o: %.xm $(THEOS_OBJ_DIR)/%.xm.mm
 	$(ECHO_NOTHING)mkdir -p $(dir $@)$(ECHO_END)
 	$(ECHO_COMPILING)$(ECHO_UNBUFFERED)$(TARGET_CXX) -x objective-c++ -c -I"$(call __clean_pwd,$(dir $<))" $(_THEOS_INTERNAL_IFLAGS_C) $(ALL_DEPFLAGS) $(ALL_CFLAGS) $(ALL_OBJCFLAGS) $(ALL_CCFLAGS) $(ALL_OBJCCFLAGS) $(THEOS_OBJ_DIR)/$<.mm -o $@$(ECHO_END)
+	$(ECHO_NOTHING)rm $(THEOS_OBJ_DIR)/$<.mm$(ECHO_END)
 
 $(THEOS_OBJ_DIR)/%.mi: %.xi
 	$(ECHO_NOTHING)mkdir -p $(dir $@)$(ECHO_END)
@@ -277,6 +279,7 @@ $(THEOS_OBJ_DIR)/%.mi: %.xi
 $(THEOS_OBJ_DIR)/%.xi.$(_THEOS_OBJ_FILE_TAG).o: %.xi $(THEOS_OBJ_DIR)/%.mi
 	$(ECHO_NOTHING)mkdir -p $(dir $@)$(ECHO_END)
 	$(ECHO_COMPILING)$(ECHO_UNBUFFERED)$(TARGET_CXX) -x objective-c -c $(ALL_CFLAGS) $(ALL_OBJCFLAGS) $(THEOS_OBJ_DIR)/$<.mi -o $@$(ECHO_END)
+	$(ECHO_NOTHING)rm $(THEOS_OBJ_DIR)/$*.mi$(ECHO_END)
 
 $(THEOS_OBJ_DIR)/%.mii: %.xmi
 	$(ECHO_NOTHING)mkdir -p $(dir $@)$(ECHO_END)
@@ -286,6 +289,7 @@ $(THEOS_OBJ_DIR)/%.mii: %.xmi
 $(THEOS_OBJ_DIR)/%.xmi.$(_THEOS_OBJ_FILE_TAG).o: %.xmi $(THEOS_OBJ_DIR)/%.mii
 	$(ECHO_NOTHING)mkdir -p $(dir $@)$(ECHO_END)
 	$(ECHO_COMPILING)$(ECHO_UNBUFFERED)$(TARGET_CXX) -x objective-c++ -c $(ALL_CFLAGS) $(ALL_OBJCFLAGS) $(ALL_CCFLAGS) $(ALL_OBJCCFLAGS) $(THEOS_OBJ_DIR)/$<.mii -o $@$(ECHO_END)
+	$(ECHO_NOTHING)rm $(THEOS_OBJ_DIR)/$*.mii$(ECHO_END)
 
 define _THEOS_TEMPLATE_DEFAULT_LINKING_RULE
 ifeq ($(TARGET_LIPO),)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- If fakeroot or its two supported alternatives are missing, and the 'required' flag is specified, prompt the user and continue to silently ignore the requested operation.
- Manually remove the processed logos files *before* we've moved on to linking so they're not treated as intermediates by make and removed automatically (where there's no easy way to quiet the removal notice).

Does this close any currently open issues?
------------------------------------------
Resolves #325 and #492 

Any relevant logs, error output, etc?
-------------------------------------
Nope.

Any other comments?
-------------------
Nope.

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
