### PR TITLE
Advise against the use of GO_EASY_ON_ME and add periods to the ends of a few print statements

### DIFF
--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -164,6 +164,10 @@ before-$(THEOS_CURRENT_INSTANCE)-all::
 		fi; \
 	done
 
+ifeq ($(GO_EASY_ON_ME).$(DEBUG),1.0)
+	@$(PRINT_FORMAT_WARNING) "GO_EASY_ON_ME quiets all errors, which is bad practice. Please migrate to Clang directives (e.g., -Wno-<blah> or #pragma clang diagnostic)." >&2
+endif
+
 after-$(THEOS_CURRENT_INSTANCE)-all::
 	@:
 

--- a/makefiles/master/rules.mk
+++ b/makefiles/master/rules.mk
@@ -11,7 +11,7 @@ _THEOS_IS_MAKE_GT_4_0 := $(call __vercmp,$(MAKE_VERSION),gt,4.0)
 ifeq ($(_THEOS_IS_MAKE_GT_4_0)$(THEOS_IGNORE_PARALLEL_BUILDING_NOTICE),)
 ifneq ($(shell $(or $(_THEOS_PLATFORM_GET_LOGICAL_CORES),:)),1)
 all::
-	@$(PRINT_FORMAT) "Build may be slow as Theos isn’t using all available CPU cores on this computer. Consider upgrading GNU Make: https://theos.dev/docs/parallel-building"
+	@$(PRINT_FORMAT) "Build may be slow as Theos isn’t using all available CPU cores on this computer. Consider upgrading GNU Make: https://theos.dev/docs/parallel-building."
 endif
 endif
 THEOS_USE_PARALLEL_BUILDING := $(_THEOS_IS_MAKE_GT_4_0)

--- a/makefiles/messages.mk
+++ b/makefiles/messages.mk
@@ -88,9 +88,9 @@ endif
 	ERROR_BEGIN = @$(PRINT_FORMAT_ERROR) $(NULLSTRING)
 	ERROR_END = $(NULLSTRING) >&2; exit 1;
 
-WARNING_EMPTY_LINKING = @$(PRINT_FORMAT_WARNING) "No files to link. Please check your Makefile! Make sure you set $(THEOS_CURRENT_INSTANCE)_FILES (or similar variables)"
+WARNING_EMPTY_LINKING = @$(PRINT_FORMAT_WARNING) "No files to link. Please check your Makefile! Make sure you set $(THEOS_CURRENT_INSTANCE)_FILES (or similar variables)."
 
 # (bundle)
-NOTICE_EMPTY_LINKING = @$(PRINT_FORMAT_WARNING) "No files to link - creating a bundle containing only resources"
+NOTICE_EMPTY_LINKING = @$(PRINT_FORMAT_WARNING) "No files to link - creating a bundle containing only resources."
 
 $(eval $(call __mod,messages.mk))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
1) Will present a stylized warning to the user if GO_EASY_ON_ME=1 and DEBUG=0 before each project's 'all' job that advises them to migrate to Clang directives 

2) Adds missing periods to a few PRINT_FORMAT* statements

Does this close any currently open issues?
------------------------------------------
Should resolve #179 

Any relevant logs, error output, etc?
-------------------------------------
```
> Making all for bundle test…
==> Warning: GO_EASY_ON_ME quiets all errors, which is bad practice. Please migrate to Clang directives (e.g., -Wno-<blah> or #pragma clang diagnostic).
==> Copying resource directories into the bundle wrapper…
==> Compiling XXXRootListController.m (arm64)…
```

Any other comments?
-------------------
Nope

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
