### PR TITLE
Handle attempting to update theos as root

### DIFF
--- a/bin/update-theos
+++ b/bin/update-theos
@@ -5,22 +5,30 @@ has() {
 	type "$1" >/dev/null 2>&1
 }
 
+# Root is no bueno
+if [[ $EUID -eq 0 ]]; then
+	echo "Theos should NOT be installed with or run as root (su/sudo)!" >&2
+	echo "  - If you've installed Theos as root, please remove the install and reinstall as a non-root user." >&2
+	echo "  - If you're using root because you don't have write permission for Theos' parent directory, please either install Theos to a different directory where you do have write permission or, if you're trying to install to /opt, change the directory's ownership before attempting to install Theos as a non-root user." >&2
+	exit 1
+fi
+
 # Ensure $THEOS is set and is a directory.
 if [[ -z "$THEOS" || ! -d "$THEOS" ]]; then
 	echo "\$THEOS must be set to the location of Theos to use $(basename $0)." >&2
-	exit 1
+	exit 2
 fi
 
 # Ensure $THEOS is a Git repo.
 if [[ ! -d "$THEOS/.git" ]]; then
 	echo "$THEOS is not a Git repository. Theos relies on Git to update itself. For more information, refer to https://theos.dev/install#updating." >&2
-	exit 2
+	exit 3
 fi
 
 # Ensure the user has Git.
 if ! has git; then
 	echo "Git is not installed. Theos relies on Git to update itself. For more information, refer to https://theos.dev/install." >&2
-	exit 2
+	exit 3
 fi
 
 cd "$THEOS"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Checks for root in `update-theos` and prompts the user to 1) not use root and 2) adjust their install location if that's the driving factor

Does this close any currently open issues?
------------------------------------------
It should resolve #406 

Any relevant logs, error output, etc?
-------------------------------------
```
Theos should NOT be installed with or run as root (su/sudo)!
  - If you've installed Theos as root, please remove the install and reinstall as a non-root user.
  - If you're using root because you don't have write permission for Theos' parent directory, please either install Theos to a different directory where you do have write permission or, if you're trying to install to /opt, change the directory's ownership before attempting to install Theos as a non-root user.
```

Any other comments?
-------------------
I tried to make the error as helpful as possible, but if you'd like me to slim it down just say the word. 

Where has this been tested?
---------------------------
**Operating System:** …

iOS - 14.3 - Taurine  

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
