### PR TITLE
Add rpaths and libraries for libhooker

### DIFF
--- a/makefiles/instance/tweak.mk
+++ b/makefiles/instance/tweak.mk
@@ -15,6 +15,9 @@ _THEOS_INTERNAL_LOGOSFLAGS += -c generator=$(_LOCAL_LOGOS_DEFAULT_GENERATOR)
 ifeq ($(_LOCAL_LOGOS_DEFAULT_GENERATOR),MobileSubstrate)
 _THEOS_INTERNAL_LDFLAGS += -F$(THEOS_VENDOR_LIBRARY_PATH) -framework CydiaSubstrate
 endif
+ifeq ($(_LOCAL_LOGOS_DEFAULT_GENERATOR),libhooker)
+_THEOS_INTERNAL_LDFLAGS += -lhooker -lblackjack -rpath /usr/lib -rpath /var/jb/usr/lib/
+endif
 
 include $(THEOS_MAKE_PATH)/instance/library.mk
 

--- a/makefiles/instance/tweak.mk
+++ b/makefiles/instance/tweak.mk
@@ -16,7 +16,7 @@ ifeq ($(_LOCAL_LOGOS_DEFAULT_GENERATOR),MobileSubstrate)
 _THEOS_INTERNAL_LDFLAGS += -F$(THEOS_VENDOR_LIBRARY_PATH) -framework CydiaSubstrate
 endif
 ifeq ($(_LOCAL_LOGOS_DEFAULT_GENERATOR),libhooker)
-_THEOS_INTERNAL_LDFLAGS += -lhooker -lblackjack -rpath /usr/lib -rpath /var/jb/usr/lib/
+_THEOS_INTERNAL_LDFLAGS += -rpath /usr/lib -rpath /var/jb/usr/lib/
 endif
 
 include $(THEOS_MAKE_PATH)/instance/library.mk


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds rpaths and libraries for libhooker and libblackjack when using a logos generator for libhooker

Does this close any currently open issues?
------------------------------------------

Any relevant logs, error output, etc?
-------------------------------------

Any other comments?
-------------------
Required for rootless support on iOS 15. Also compatible with pre-rootless libhooker (assuming the tbds pushed to the libs repo are used).

Verified rpaths are added via otool and tweak loads on iOS 15

Where has this been tested?
---------------------------

**Platform:** macOS

**Target Platform:** iOS 15.0.1

**Toolchain Version:** Xcode 13.2.1

**SDK Version:** iOS 15.2
