### PR TITLE
Point clang to the proper ld when the toolchain's binaries have prefixes

### DIFF
--- a/makefiles/targets/Linux/iphone.mk
+++ b/makefiles/targets/Linux/iphone.mk
@@ -12,9 +12,9 @@ SDKBINPATH ?= $(THEOS)/toolchain/$(THEOS_PLATFORM_NAME)/$(THEOS_TARGET_NAME)/bin
 
 # Determine toolchain to use based on file existence.
 ifeq ($(_THEOS_TARGET_SDK_BIN_PREFIX),)
-ifeq ($(call __exists, $(SDKBINPATH)/armv7-apple-darwin11-ld),$(_THEOS_TRUE))
+ifeq ($(call __exists,$(SDKBINPATH)/armv7-apple-darwin11-ld),$(_THEOS_TRUE))
 _THEOS_TARGET_SDK_BIN_PREFIX ?= armv7-apple-darwin11-
-else ifeq ($(call __exists, $(SDKBINPATH)/arm64-apple-darwin14-ld),$(_THEOS_TRUE))
+else ifeq ($(call __exists,$(SDKBINPATH)/arm64-apple-darwin14-ld),$(_THEOS_TRUE))
 _THEOS_TARGET_SDK_BIN_PREFIX ?= arm64-apple-darwin14-
 else
 # toolchain has no prefix so we are responsible of supplying target triple to clang for cross compiling

--- a/makefiles/targets/_common/darwin_tail.mk
+++ b/makefiles/targets/_common/darwin_tail.mk
@@ -35,6 +35,11 @@ _THEOS_TARGET_CFLAGS := -isysroot "$(ISYSROOT)" $(VERSIONFLAGS) $(_THEOS_TARGET_
 _THEOS_TARGET_CCFLAGS := $(_TARGET_LIBCPP_CCFLAGS)
 _THEOS_TARGET_LDFLAGS := -isysroot "$(SYSROOT)" $(VERSIONFLAGS) $(LEGACYFLAGS) -multiply_defined suppress $(_TARGET_LIBCPP_LDFLAGS) $(_TARGET_LIBSWIFT_LDFLAGS)
 
+# if toolchain has prefix, point clang to the ld we want to use
+ifneq ($(_THEOS_TARGET_SDK_BIN_PREFIX),)
+_THEOS_TARGET_LDFLAGS += -fuse-ld=$(SDKBINPATH)/$(_THEOS_TARGET_SDK_BIN_PREFIX)ld
+endif
+
 _THEOS_TARGET_SWIFTFLAGS := -sdk "$(SYSROOT)" $(_THEOS_TARGET_CC_SWIFTFLAGS)
 _THEOS_TARGET_SWIFT_LDPATHS = $(call __simplify,_THEOS_TARGET_SWIFT_LDPATHS,$(dir $(shell type -p $(TARGET_SWIFT)))../lib/swift/$(_THEOS_TARGET_PLATFORM_NAME) /usr/lib/swift)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Points clang to the toolchain's ld when the tc binaries have prefixes

Does this close any currently open issues?
------------------------------------------
Appears to resolve #528 

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
~ hacky ~

Tested by adding prefixes to Sam's latest toolchain with:
```
pushd $THEOS/toolchain/linux/iphone/bin
find * ! -name clang-10 -and ! -name ldid -and ! -name ld64 -exec mv {} arm64-apple-darwin14-{} \;
find * -xtype l -exec sh -c "readlink {} | xargs -I{LINK} ln -f -s arm64-apple-darwin14-{LINK} {}" \;
popd
```

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
