### PR TITLE
Handle paths with spaces in convert_xml_plist.sh

### DIFF
--- a/bin/convert_xml_plist.sh
+++ b/bin/convert_xml_plist.sh
@@ -33,7 +33,7 @@ readarray -t results_array <<< "$results"
 # Check to see if files are in xml format or binary
 for i in "${results_array[@]}"; do
 	# Grab printable characters from file's bytes
-	head=$(od -c $i | head)
+	head=$(od -c "$i" | head)
 	# Strip any non-letter charcters
 	clean_head=${head//[^[:alpha:]]/}
 	# bplist's have an 8 byte header ([bplist##] where ## is the version)
@@ -44,11 +44,11 @@ for i in "${results_array[@]}"; do
 	# If file wasn't in binary format, convert it
 	if ! [[ ${magic_bytes,,} == "bplist" ]]; then
 		if [[ $cmd == "plutil" ]]; then
-			plutil -convert binary1 $i
+			plutil -convert binary1 "$i"
 		elif [[ $cmd == "ply" ]]; then
-			ply -c binary $i
+			ply -c binary "$i"
 		else
-			plistutil -i $i -f bin -o $i
+			plistutil -i "$i" -f bin -o "$i"
 		fi
 	fi
 done


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------

Suppose there is a whitespace in the path to a plist or a strings;

`/Library/Application Support/YouPiP.bundle/en.lproj/Localizable.strings`

When the script is executed, `od` command will fail because `$i` contains a whitespace:

`od: Support/YouPiP.bundle/en.lproj/Localizable.strings: No such file or directory`

Ensuring that all references to `$i` are double quoted prevents such issue.

Does this close any currently open issues?
------------------------------------------
No one reported it, yet.


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** macOS

**Target Platform:** iOS

**Toolchain Version:** …

**SDK Version:** …
