### PR TITLE
Implement Filter.plist as a reserved keyword

### DIFF
--- a/makefiles/instance/tweak.mk
+++ b/makefiles/instance/tweak.mk
@@ -40,9 +40,11 @@ endif
 ifneq ($($(THEOS_CURRENT_INSTANCE)_INSTALL),0)
 internal-tweak-stage_:: $(_EXTRA_TARGET) internal-library-stage_
 ifeq ($(call __exists,$(THEOS_CURRENT_INSTANCE).plist),$(_THEOS_TRUE))
-	$(ECHO_NOTHING)cp $(THEOS_CURRENT_INSTANCE).plist "$(THEOS_STAGING_DIR)$(LOCAL_INSTALL_PATH)/"$(ECHO_END)
-else ifeq ($(call __exists,$(THEOS_LAYOUT_DIR_NAME)/$(LOCAL_INSTALL_PATH)/$(THEOS_CURRENT_INSTANCE).plist),$(_THEOS_FALSE))
-	$(ERROR_BEGIN)"You are missing a filter property list. Make sure it’s named $(THEOS_CURRENT_INSTANCE).plist. Refer to http://iphonedevwiki.net/index.php/Cydia_Substrate#MobileLoader."$(ERROR_END)
+	$(ECHO_NOTHING)cp "$(THEOS_CURRENT_INSTANCE).plist" "$(THEOS_STAGING_DIR)$(LOCAL_INSTALL_PATH)/$(THEOS_CURRENT_INSTANCE).plist"$(ECHO_END)
+else ifeq ($(call __exists,Filter.plist),$(_THEOS_TRUE))
+	$(ECHO_NOTHING)cp "Filter.plist" "$(THEOS_STAGING_DIR)$(LOCAL_INSTALL_PATH)/$(THEOS_CURRENT_INSTANCE).plist"$(ECHO_END)
+else
+	$(ERROR_BEGIN)"You are missing a filter property list. Make sure it’s named \"$(THEOS_CURRENT_INSTANCE).plist\" or \"Filter.plist\". Refer to http://iphonedevwiki.net/index.php/Cydia_Substrate#MobileLoader."$(ERROR_END)
 endif
 endif
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
For tweak projects, this PR allows the Substrate Filter Plist to be named `Filter.plist` as a reserved keyword, instead of forcing the plist to be named whatever `TWEAK_NAME` is. This is useful for an instance-based design - i.e. if developers wish to have a consistent file system layout across multiple projects. 

Note that this PR is in addition to TWEAK_NAME.pllist, not instead of. It will first try for TWEAK_NAME.plist. If available, great, and if not, it will fallback to trying Filter.plist. If that is available, great, and if not, it will throw an error. 

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Operating System:** macOS Monterey 12.3.1

**Platform:** macOS

**Target Platform:** iOS

**Toolchain Version:** N/A

**SDK Version:** 14.5
