### PR TITLE
Adjust sysroot errors to better explain the issue at hand

### DIFF
--- a/makefiles/master/rules.mk
+++ b/makefiles/master/rules.mk
@@ -41,12 +41,13 @@ clean:: before-clean internal-clean after-clean
 do:: all package install
 
 before-all::
-# If the sysroot is set but doesn’t exist, bail out.
+# If the chosen sdk doesn’t exist, the sysroot will be blank, bail out.
 ifeq ($(SYSROOT),)
-	$(ERROR_BEGIN) "A SYSROOT could not be found. For instructions on installing an SDK: https://theos.dev/docs/installation" $(ERROR_END)
+	$(ERROR_BEGIN) "Your chosen SDK, “$(_THEOS_TARGET_PLATFORM_SDK_NAME)$(_THEOS_TARGET_SDK_VERSION).sdk”, does not appear to exist." $(ERROR_END)
 else
+# If the SYSROOT is set but doesn’t exist, bail out.
 ifneq ($(call __exists,$(SYSROOT)),$(_THEOS_TRUE))
-	$(ERROR_BEGIN) "Your current SYSROOT, “$(SYSROOT)”, appears to be missing." $(ERROR_END)
+	$(ERROR_BEGIN) "Your chosen SYSROOT, “$(SYSROOT)”, does not appear to exist." $(ERROR_END)
 endif
 endif
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Does this close any currently open issues?
------------------------------------------
I don't think so, no 

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
Improves upon 41007e9d2705a3fd38409b3f567339e189713aee

Previously, a failed SYSROOT check indicated to users that they did not have an SDK, but more often than not they had just specified an SDK that did not exist and thus the SYSROOT had been blanked.  

The current situation: 
- The Theos and Xcode SDK directories are checked in darwin_head.mk
  - If both return blank (i.e., the user lacks SDKs), the build will fail w/ an error. 
  - If not, the specified SDK's existence is evaluated in darwin_tail.mk.
    - If it does not exist, the SYSROOT will be left empty. 
    - Either way, the SYSROOT is evaluated in the master rules.mk.
      - If the SYSROOT has not been overridden but the chosen SDK does not exist, as indicated by a blank SYSROOT, the build will fail w/ an error.
      - If the SYSROOT has been incorrectly overridden, the build will fail w/ an error.

Example cases:
```make
export SYSROOT = /some/dir
```
```console
==> Error: Your chosen SYSROOT, “/some/dir”, does not appear to exist.
```
and
```make
export TARGET = iphone:clang:99.9:10.0
```
```console
==> Error: Your chosen SDK, “iPhoneOS99.9.sdk”, does not appear to exist.
```

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
