### PR TITLE
Fix procursus repo url on darwin-mobile

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -232,7 +232,7 @@ darwin_mobile() {
 	else
 		# Up-to-date dependencies pkg is exclusive to Procursus, so need to cater install accordingly
 		if [[ -f /.procursus_strapped ]]; then
-			read -p "Do you have 'https://apt.procursus.us' installed in the sources of your jailbreak's primary package manager? [y/n]" ready
+			read -p "Do you have 'https://apt.procurs.us' installed in the sources of your jailbreak's primary package manager? [y/n]" ready
 			if theos_bool $ready; then
 				sudo apt update --allow-insecure-repositories
 				sudo apt install -y --allow-downgrades theos-dependencies \


### PR DESCRIPTION
I have just fixed a wrong url in the installer. When trying to install theos on iOS 12+ it askes if you have https://apt.procursus.us repo in on your package manager. I have changed it to ask for https://apt.procurs.us which is the correct url.