### PR TITLE
[bin] remove dnf check-update during dependency install

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -318,8 +318,7 @@ linux() {
 				|| (error "Dependency install command seems to have encountered an error. Please see the log above."; exit 3)
 			;;
 		redhat)
-			sudo dnf check-update
-			sudo dnf group install -y "C Development Tools and Libraries" \
+			sudo dnf group install -y "C Development Tools and Libraries" --refresh \
 				&& update "Dependencies have been successfully installed!" \
 				|| (error "Dependency install command seems to have encountered an error. Please see the log above."; exit 3)
 			sudo dnf install -y fakeroot lzma libbsd rsync curl perl zip git libxml2 \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The `dnf check-update` command in the installer lists the updatable packages and quits the script if there's any.
To fix it, at first I just changed it to `dnf update` which does update them, and it worked.

However, the Debian and Arch behaviours appear to be to "refresh the sources" as opposed to "update the system packages" (`apt update` vs `apt upgrade`, `pacman -Syy` vs `pacman -Syu`) and `dnf update` doesn't follow that intended behaviour.

To make sure the repositories are forcefully updated by dnf, the `--refresh` flag was added to the next line which installs some dependencies.

Does this close any currently open issues?
------------------------------------------
Closes #738.

Any relevant logs, error output, etc?
-------------------------------------
None

Any other comments?
-------------------
All that being said, there's a whole thing going on with [Arch partial upgrades](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported), so maybe `pacman -Syu` would be the way to go for that.

There also appears to be another issue which is similar to this but on Ubuntu (#736), which is weird because from what I remember `apt update` does just update the repos and moves on, but I can't test a fix currently.

Where has this been tested?
---------------------------
**Operating System:** Fedora 38

**Platform:** WSL2
