### PR TITLE
Fix `install-theos` for rootless

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -235,7 +235,7 @@ darwin_mobile() {
 		fi
 	else
 		# Up-to-date dependencies pkg is exclusive to Procursus, so need to cater install accordingly
-		if [[ -f /.procursus_strapped ]]; then
+		if [[ -f /.procursus_strapped || -f /var/jb/.procursus_strapped ]]; then
 			read -p "Do you have 'https://apt.procurs.us' installed in the sources of your jailbreak's primary package manager? [y/n]" ready
 			if theos_bool $ready; then
 				sudo apt update --allow-insecure-repositories
@@ -264,7 +264,7 @@ darwin_mobile() {
 	update "Checking desire for Swift support..."
 	read -p "Would you like to be able to work with Swift? If so, an additional package will need to be installed. [y/n]" confirm
 	if theos_bool $confirm; then
-		if [[ -f /.procursus_strapped ]]; then
+		if [[ -f /.procursus_strapped || -f /var/jb/.procursus_strapped ]]; then
 			sudo apt install -y --allow-downgrades swift \
 				&& update "Additional Swift package installation successful!" \
 				|| (error "Additional Swift package install command seems to have encountered an error. Please see the log above."; exit 3)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Does this close any currently open issues?
------------------------------------------
I don't think so

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
- Currently will prompt for apt.bingner.com instead of procursus as the marker file check fails 
  - File is now in prefixed path instead of root
- Untested 

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
