### PR TITLE
Fix shell profile ordering in installer

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -46,14 +46,23 @@ PLATFORM=$(uname)
 CSHELL="${SHELL##*/}"
 SHELL_ENV="unknown"
 if [[ $CSHELL == sh || $CSHELL == bash || $CSHELL == dash ]]; then
-	# Arch doesn't have/read from .profile :/
-	if [[ -f $HOME/.bash_profile && ! -f $HOME/.profile ]]; then
+	# Bash prioritizes bashrc > bash_profile > profile
+	if [[ -f $HOME/.bashrc ]]; then
+		SHELL_ENV="$HOME/.bashrc"
+	elif [[ -f $HOME/.bash_profile ]]; then
 		SHELL_ENV="$HOME/.bash_profile"
 	else
 		SHELL_ENV="$HOME/.profile"
 	fi
 elif [[ $CSHELL == zsh ]]; then
-	SHELL_ENV="$HOME/.zshenv"
+	# Zsh prioritizes zshenv > zprofile > zshrc
+	if [[ -f $HOME/.zshenv ]]; then
+		SHELL_ENV="$HOME/.zshenv"
+	elif [[ -f $HOME/.zprofile ]]; then
+		SHELL_ENV="$HOME/.zprofile"
+	else
+		SHELL_ENV="$HOME/.zshrc"
+	fi
 # TODO
 # elif [[ $CSHELL == csh ]]; then
 # 	SHELL_ENV="$HOME/.cshrc"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
Ref: https://shreevatsa.wordpress.com/2008/03/30/zshbash-startup-files-loading-order-bashrc-zshrc-etc/

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
