### PR TITLE
Add flock to gen-commands.pl to avoid race condition

### DIFF
--- a/bin/gen-commands.pl
+++ b/bin/gen-commands.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/perl
 use JSON::PP;
+use Fcntl ':flock';
 
 $filename = shift;
 $dir = shift;
@@ -16,23 +17,26 @@ while (true) {
 
 # read out existing compile_commands and clear the file
 if (-e $filename) {
-    open(FH, '+<', $filename) or die $!;
+    open(FH, '+<', $filename) or die "Could not open '$filename' - $!";
+    flock(FH, LOCK_EX) or die "Could not lock '$filename' - $!";
     @commands = @{decode_json(<FH>)};
     seek(FH, 0, 0);
 } else {
-    open(FH, '>', $filename) or die $!;
+    open(FH, '>', $filename) or die "Could not open '$filename' - $!";
+    flock(FH, LOCK_EX) or die "Could not lock '$filename' - $!";
     @commands = ();
 }
 
 foreach (@files) {
     push(@commands, {
-        directory => $dir,
-        file => $_,
+        directory => "$dir",
+        file => "$_",
         command => join(" ", @ARGV)
     });
 }
 
 print FH encode_json(\@commands);
 truncate(FH, tell(FH));
+close(FH) or die "Could not write '$filename' - $!";
 
 exec @ARGV;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
I am not a pro in Perl. But `make commands` sometimes fails to generate a valid json if parallel building is enabled.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
No, but I found clangd sometimes refused to load compile_commands.json due to syntax errors.

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
