### PR TITLE
Only make FAT bin if TARGET_ARCHS > 1

### DIFF
--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -476,7 +476,11 @@ endif
 ifeq ($$(_THEOS_CURRENT_TYPE),subproject)
 	@echo "$$(_THEOS_INTERNAL_LDFLAGS)" > $$(THEOS_OBJ_DIR)/$$(THEOS_CURRENT_INSTANCE).ldflags
 endif
+ifneq ($(words $(TARGET_ARCHS)),1)
 	$(ECHO_MERGING)$(ECHO_UNBUFFERED)$(TARGET_LIPO) $(foreach ARCH,$(TARGET_ARCHS),-arch $(ARCH) $(THEOS_OBJ_DIR)/$(ARCH)/$(1)) -create -output "$$@"$(ECHO_END)
+else
+	$(ECHO_NOTHING)cp -a $(THEOS_OBJ_DIR)/$(TARGET_ARCHS)/$(1) "$$@"$(ECHO_END)
+endif
 
 else
 $$(THEOS_OBJ_DIR)/$(1): $$(OBJ_FILES_TO_LINK)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Keeps single-arch projects single-arch thin bins

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
See convo with Daniel/Leptos in the Theos Discord (#theos-general)

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
