### PR TITLE
Update `install-theos` for sdk releases

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -144,11 +144,12 @@ get_sdks() {
 		update "SDKs appear to already be installed."
 	else
 		update "SDKs do not appear to be installed. Installing now..."
-		curl -L https://api.github.com/repos/theos/sdks/tarball -o sdks.tar.gz
-		TMP=$(mktemp -d)
-		tar -xvf sdks.tar.gz --strip=1 -C $TMP
-		mv $TMP/*.sdk $THEOS/sdks
-		rm -r sdks.tar.gz $TMP
+		# Grab latest for provided platforms
+		urls=$(curl https://api.github.com/repos/theos/sdks/releases/latest | grep download_url | sed 's/.*: "\(.*\)"/\1/')
+		ios_url=$(echo "$urls" | grep 'iPhoneOS' | sort -V | tail -n1)
+		tvos_url=$(echo "$urls" | grep 'AppleTVOS' | sort -V | tail -n1)
+		curl -L "$ios_url" | tar -xJv -C "$THEOS/sdks"
+		curl -L "$tvos_url" | tar -xJv -C "$THEOS/sdks"
 
 		if [[ -d $THEOS/sdks/ && $(ls -A "$THEOS/sdks/" | grep sdk) ]]; then
 			update "SDKs successfully installed!"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Switches sdk install to latest for each platform instead of all we provide

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
- Reliant on [theos/sdks#67](https://github.com/theos/sdks/pull/67)
- Someone on OSX please confirm that none of the flags used are GNU-specific

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
