### PR TITLE
[workflows] Update actions/checkout to v4

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.UPDATE_SUBMODULES_TOKEN }}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

`actions/checkout` v2 uses node12 which has been deprecated on GitHub Actions. We can see this warning on any recent Action run on this workflow, for example: https://github.com/theos/theos/actions/runs/7160553166

Does this close any currently open issues?
------------------------------------------
no


Any relevant logs, error output, etc?
-------------------------------------

See warning on https://github.com/theos/theos/actions/runs/7160553166

Any other comments?
-------------------

Difficult to test the full Action, but should work.

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
