### PR TITLE
Use `allow_simulator_linking_to_macosx_dylibs` linker flag only for clang <= 14.0.0

### DIFF
--- a/makefiles/targets/Darwin/simulator.mk
+++ b/makefiles/targets/Darwin/simulator.mk
@@ -47,5 +47,10 @@ _TARGET_OBJC_ABI_CFLAGS := $(if $(_TARGET_VERSION_GE_3_2),-fobjc-abi-version=2 -
 _TARGET_OBJC_ABI_LDFLAGS := $(if $(_TARGET_VERSION_GE_3_2),-Xlinker -objc_abi_version -Xlinker 2)
 
 _THEOS_TARGET_CFLAGS += $(_TARGET_OBJC_ABI_CFLAGS)
+_TARGET_CC_VERSION_GE_1500 := $(call __vercmp,$(_THEOS_TARGET_CC_VERSION),ge,15.0.0)
+ifeq ($(_TARGET_CC_VERSION_GE_1500),1)
+_THEOS_TARGET_LDFLAGS += $(_TARGET_OBJC_ABI_LDFLAGS)
+else
 _THEOS_TARGET_LDFLAGS += $(_TARGET_OBJC_ABI_LDFLAGS) -Xlinker -allow_simulator_linking_to_macosx_dylibs
+endif
 endif


### PR DESCRIPTION
Somehow, clang 15.0.0 and higher deprecates this flag on Apple Silicon but removes this flag on Intel platform. To fix the issue for both worlds, we just don't need this flag for clang 15.0.0 and higher. This doesn't affect the dylibs built for simulator and will still work fine.

<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
