### PR TITLE
Use oldabi libroot file when compiling with clang < 12.0.0

### DIFF
--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -118,6 +118,13 @@ _THEOS_INTERNAL_LDFLAGS += $(foreach library,$(call __schema_var_all,$(THEOS_CUR
 # Static libraries do not support having multiple arm64e ABIs, we need to manually choose the correct ABI
 IS_NEW_ABI := $(call __vercmp,$(_THEOS_TARGET_CC_VERSION),ge,12.0.0)
 ifeq ($(IS_NEW_ABI),1)
+ifneq ($(THEOS_PLATFORM_NAME),macosx)
+# On non macOS, always use old ABI as only macOS can compile with new ABI
+IS_NEW_ABI = 0
+endif
+endif
+
+ifeq ($(IS_NEW_ABI),1)
 ABI_SUFFIX = 
 else
 ABI_SUFFIX = _oldabi

--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -115,8 +115,16 @@ _THEOS_INTERNAL_LDFLAGS += $(foreach framework,$(call __schema_var_all,$(THEOS_C
 _THEOS_INTERNAL_LDFLAGS += $(foreach library,$($(_THEOS_CURRENT_TYPE)_WEAK_LIBRARIES),-weak_library $(library))
 _THEOS_INTERNAL_LDFLAGS += $(foreach library,$(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,WEAK_LIBRARIES),-weak_library $(library))
 
+# Static libraries do not support having multiple arm64e ABIs, we need to manually choose the correct ABI
+IS_NEW_ABI := $(call __vercmp,$(_THEOS_TARGET_CC_VERSION),ge,12.0.0)
+ifeq ($(IS_NEW_ABI),1)
+ABI_SUFFIX = 
+else
+ABI_SUFFIX = _oldabi
+endif
+
 # Add libroot (v2)
-_THEOS_INTERNAL_LDFLAGS += -lroot
+_THEOS_INTERNAL_LDFLAGS += -lroot$(ABI_SUFFIX)
 
 _THEOS_INTERNAL_CFLAGS += -D THEOS_PACKAGE_INSTALL_PREFIX="\"$(THEOS_PACKAGE_INSTALL_PREFIX)\""
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
RIght now compilation for oldabi fails due to libroot only having a new ABI file.
Initially I tried using a patched lipo to combine both old ABI and new ABI slices into the same .a, this however does not work.
Now there are two .a files, one with an old ABI arm64e slice and one with a new one and we use the correct one based on the clang version being used when compiling.

Depends on https://github.com/theos/lib/pull/23 being merged first.

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** macOS

**Target Platform:** iOS
