### PR TITLE
Make the linker verbose when passing messages=yes.

### DIFF
--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -188,10 +188,12 @@ _THEOS_INTERNAL_SEARCHPATHS += \
 	$(THEOS_VENDOR_LIBRARY_PATH)/$(THEOS_TARGET_NAME)/$(or $(THEOS_PACKAGE_SCHEME),rootful) \
 	$(THEOS_LIBRARY_PATH)/$(THEOS_TARGET_NAME)/$(or $(THEOS_PACKAGE_SCHEME),rootful)
 
-ifeq ($(messages),$(filter $(messages),true 1 yes))
-_THEOS_INTERNAL_LDFLAGS = -v $(foreach path,$(_THEOS_INTERNAL_SEARCHPATHS),$(if $(call __exists,$(path)),-L$(path) -F$(path))) $(DEBUGFLAG)
-else
 _THEOS_INTERNAL_LDFLAGS = $(foreach path,$(_THEOS_INTERNAL_SEARCHPATHS),$(if $(call __exists,$(path)),-L$(path) -F$(path))) $(DEBUGFLAG)
+
+include $(THEOS_MAKE_PATH)/messages.mk
+
+ifeq ($(_THEOS_VERBOSE),$(_THEOS_TRUE))
+_THEOS_INTERNAL_LDFLAGS += -Wl,-v
 endif
 
 DEBUGFLAG ?= -ggdb
@@ -269,8 +271,6 @@ THEOS_PACKAGE_DIR_NAME ?= packages
 THEOS_PACKAGE_DIR ?= $(THEOS_BUILD_DIR)/$(THEOS_PACKAGE_DIR_NAME)
 
 THEOS_SUBPROJECT_PRODUCT = subproject.a
-
-include $(THEOS_MAKE_PATH)/messages.mk
 
 _THEOS_MAKEFLAGS := --no-keep-going COLOR=$(COLOR)
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Makes the linker verbose when passing messages=yes.

Does this close any currently open issues?
------------------------------------------
#803 

Any relevant logs, error output, etc?
-------------------------------------
`
@(#)PROGRAM:ld  PROJECT:ld64-820.1
BUILD 20:07:01 Nov  7 2022
configured to support archs: armv6 armv7 armv7s arm64 arm64e arm64_32 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em
Library search paths:
	/Users/joshua/theos/sdks/iPhoneOS16.5.sdk/System/Library/PrivateFrameworks
	/Users/joshua/theos/vendor/lib/iphone/rootless
	/Users/joshua/theos/lib/iphone/rootless
	/Users/joshua/theos/sdks/iPhoneOS16.5.sdk/usr/lib
Framework search paths:
	/Users/joshua/theos/sdks/iPhoneOS16.5.sdk/System/Library/PrivateFrameworks
	/Users/joshua/theos/vendor/lib/iphone/rootless
	/Users/joshua/theos/lib/iphone/rootless
	/Users/joshua/theos/sdks/iPhoneOS16.5.sdk/System/Library/Frameworks/
(printf "\e[0;3%im==> \e[1;39m%s…\e[m\n" 4 "Generating debug symbols for LeaveMeAlone"); set -o pipefail; (/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil "/Users/joshua/HardcoreDND/.theos/obj/debug/arm64e/LeaveMeAlone.dylib")
`

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** macOS 12.7.4

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
