### PR TITLE
Simplify and fix WSL v1 check

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -361,9 +361,9 @@ linux() {
 
 	# Check for WSL
 	update "Checking for WSL..."
-	if [[ $(uname -r | sed -n 's/.*\( *Microsoft *\).*/\L\1/ip') == microsoft ]]; then
-		VERSION=$(uname -r | sed 's/.*\([[:digit:]]\)[[:space:]]*/\1/')
-		if [[ $VERSION -eq 1 ]]; then
+	rel="$(uname -r)"
+	if [[ ${rel,,} =~ microsoft ]]; then
+		if ! [[ $rel =~ WSL2 ]]; then
 			update "WSL1! Need to fix fakeroot..."
 			sudo update-alternatives --set fakeroot /usr/bin/fakeroot-tcp \
 				&& update "fakeroot fixed!" \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- WSL can be identified by the "[Mm]icrosoft" substring in the kernel release
  - Previously, this was checked via a lengthy two-part regex
    - Part one worked as expected but part two, the release version, would work for v2 and not v1
      - To remedy these, simpler checks are now used and the wsl v1 check was switched to a ! v2 check

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
Issue was brought to our attention through Discord

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL -- v1 and v2)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
