### PR TITLE
Ensure single-arch objs have spaces stripped before copying

### DIFF
--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -125,7 +125,7 @@ endif
 endif
 
 ifeq ($(IS_NEW_ABI),1)
-ABI_SUFFIX = 
+ABI_SUFFIX =
 else
 ABI_SUFFIX = _oldabi
 endif
@@ -494,7 +494,7 @@ endif
 ifneq ($(words $(TARGET_ARCHS)),1)
 	$(ECHO_MERGING)$(ECHO_UNBUFFERED)$(TARGET_LIPO) $(foreach ARCH,$(TARGET_ARCHS),-arch $(ARCH) $(THEOS_OBJ_DIR)/$(ARCH)/$(1)) -create -output "$$@"$(ECHO_END)
 else
-	$(ECHO_NOTHING)cp -a $(THEOS_OBJ_DIR)/$(TARGET_ARCHS)/$(1) "$$@"$(ECHO_END)
+	$(ECHO_NOTHING)cp -a $(THEOS_OBJ_DIR)/$(strip $(TARGET_ARCHS))/$(1) "$$@"$(ECHO_END)
 endif
 
 else


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Removes any spaces from the TARGET_ARCHS when its count is == 1
  - Ensures a valid UNIX path

Does this close any currently open issues?
------------------------------------------
Appears to resolve #808 

Any relevant logs, error output, etc?
-------------------------------------
**before**
```
> Making all for tweak test…
==> Preprocessing Tweak.x…
==> Compiling Tweak.x (arm64)…
==> Linking tweak test (arm64)…
==> Generating debug symbols for test…
warning: no debug symbols in executable (-arch arm64)
cp: target '/home/lightmann/test/.theos/obj/debug/test.dylib.86a9eb47.unsigned': No such file or directory
```

**after**
```
> Making all for tweak test…
==> Preprocessing Tweak.x…
==> Compiling Tweak.x (arm64)…
==> Linking tweak test (arm64)…
==> Generating debug symbols for test…
warning: no debug symbols in executable (-arch arm64)
==> Signing test…
> Making stage for tweak test…
```

Any other comments?
-------------------
I'm not sure if this is the best place to strip the variable, but it seems like it's treated elsewhere such that space(s) are of no consequence 

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
