### PR TITLE
Adjust Swift toolchain download URL for x86_64 (no arch suffix)

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -408,7 +408,9 @@ linux() {
 					return
 					;;
 			esac
-			if [[ $ARCH == aarch64 || $ARCH == x86_64 ]]; then
+			if [[ $ARCH == x86_64 ]]; then
+				curl -sL https://github.com/kabiroberai/swift-toolchain-linux/releases/download/v2.3.0/swift-5.8-ubuntu20.04.tar.xz | tar -xJvf - -C $THEOS/toolchain/
+			elif [[ $ARCH == aarch64 ]]; then
 				curl -sL https://github.com/kabiroberai/swift-toolchain-linux/releases/download/v2.3.0/swift-5.8-ubuntu20.04-$ARCH.tar.xz | tar -xJvf - -C $THEOS/toolchain/
 			else
 				common "Apologies, we do not currently provide precompiled toolchains for $ARCH Linux."


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Currently, running the install script on x86_64 and selecting the Swift toolchain fails.
This is caused by the request for the toolchain returning a 404.

Does this close any currently open issues?
------------------------------------------

No

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
Hotfix

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
