### PR TITLE
Use UPDATE_SUBMODULES_TOKEN to push in offline-docs workflow

### DIFF
--- a/.github/workflows/offline-docs.yml
+++ b/.github/workflows/offline-docs.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout theos/theos
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.UPDATE_SUBMODULES_TOKEN }}
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

The current `offline-docs` workflow fails to push the changes because of repository settings.

See https://github.com/theos/theos/actions/runs/9532349020/job/26274358604#step:7:42

This PR uses the same token as the [`update-submodules`](https://github.com/theos/theos/blob/f40d18a6e6d83f18a17b604a3426fe3c1b3dd048/.github/workflows/update-submodules.yml#L15) to access the repo, which does work.

Does this close any currently open issues?
------------------------------------------

No

Any relevant logs, error output, etc?
-------------------------------------

No.

Any other comments?
-------------------

I do not believe this change can be tested safely without pushing to `theos/theos:master`, however this is essentially a configuration change, so I'm comfortable with this.

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
