### PR TITLE
let `make commands` work for pure objective-c files

### DIFF
--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -169,6 +169,11 @@ _TARGET_CXX := $(TARGET_CXX)
 ifneq ($(firstword $(_TARGET_CXX)),$(THEOS_BIN_PATH)/gen-commands.pl)
 TARGET_CXX = $(THEOS_BIN_PATH)/gen-commands.pl $(_THEOS_TMP_COMPILE_COMMANDS_FILE) $${PWD} cxx $(filter $(__USER_FILES),$<) -- $(_TARGET_CXX)
 endif
+# add missing objective-c hook for compile-commands.json
+_TARGET_CC := $(TARGET_CC)
+ifneq ($(firstword $(_TARGET_CC)),$(THEOS_BIN_PATH)/gen-commands.pl)
+TARGET_CC = $(THEOS_BIN_PATH)/gen-commands.pl $(_THEOS_TMP_COMPILE_COMMANDS_FILE) $${PWD} cxx $(filter $(__USER_FILES),$<) -- $(_TARGET_CC)
+endif
 endif
 
 ifeq ($(TARGET_LIPO),)

--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -171,7 +171,7 @@ TARGET_CXX = $(THEOS_BIN_PATH)/gen-commands.pl $(_THEOS_TMP_COMPILE_COMMANDS_FIL
 endif
 _TARGET_CC := $(TARGET_CC)
 ifneq ($(firstword $(_TARGET_CC)),$(THEOS_BIN_PATH)/gen-commands.pl)
-TARGET_CC = $(THEOS_BIN_PATH)/gen-commands.pl $(_THEOS_TMP_COMPILE_COMMANDS_FILE) $${PWD} cxx $(filter $(__USER_FILES),$<) -- $(_TARGET_CC)
+TARGET_CC = $(THEOS_BIN_PATH)/gen-commands.pl $(_THEOS_TMP_COMPILE_COMMANDS_FILE) $${PWD} cc $(filter $(__USER_FILES),$<) -- $(_TARGET_CC)
 endif
 endif
 

--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -169,7 +169,6 @@ _TARGET_CXX := $(TARGET_CXX)
 ifneq ($(firstword $(_TARGET_CXX)),$(THEOS_BIN_PATH)/gen-commands.pl)
 TARGET_CXX = $(THEOS_BIN_PATH)/gen-commands.pl $(_THEOS_TMP_COMPILE_COMMANDS_FILE) $${PWD} cxx $(filter $(__USER_FILES),$<) -- $(_TARGET_CXX)
 endif
-# add missing objective-c hook for compile-commands.json
 _TARGET_CC := $(TARGET_CC)
 ifneq ($(firstword $(_TARGET_CC)),$(THEOS_BIN_PATH)/gen-commands.pl)
 TARGET_CC = $(THEOS_BIN_PATH)/gen-commands.pl $(_THEOS_TMP_COMPILE_COMMANDS_FILE) $${PWD} cxx $(filter $(__USER_FILES),$<) -- $(_TARGET_CC)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
this allows for creating a compile-commands.json for pure objective-c files aka .m files
which in turn allows for intellisense for these .m files

Does this close any currently open issues?
------------------------------------------
not that i am aware of


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** Debian Bookworm 12

**Platform:** 

**Target Platform:** iphone/tweak

**Toolchain Version:** 13.0

**SDK Version:** iPhone 16.5
