### PR TITLE
Use include instead of import in Prefix.pch for improved compatibility

### DIFF
--- a/Prefix.pch
+++ b/Prefix.pch
@@ -15,7 +15,7 @@
 #endif
 
 #if __has_include(<AvailabilityVersions.h>)
-	#import <AvailabilityVersions.h>
+	#include <AvailabilityVersions.h>
 #endif
 
 #if !defined(__IPHONE_14_0) && !defined(THEOS_LEAN_AND_MEAN)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This PR fixes an error when compiling projects with `-pedantic` in `CFLAGS`.

The issue is that `import` is not supported in pedantic mode. To resolve this issue, this PR uses `include` instead of `import`. This is safe because the header being included uses a guard check to avoid being included multiple times: https://github.com/theos/sdks/blob/ca52092676249546f08657d4fc0c8beb26a80510/iPhoneOS16.5.sdk/usr/include/AvailabilityVersions.h#L24 

This is primary difference between `import` and `include`.

This PR only changes this one `import` in `Prefix.pch` because the rest of the file is deprecated.

Does this close any currently open issues?
------------------------------------------

Yes, #819 

Any relevant logs, error output, etc?
-------------------------------------

No

Any other comments?
-------------------

Tested by compiling https://github.com/leptos-null/ClassDumpRuntime and https://github.com/pixelomer/libunarr-ios

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iOS

**Toolchain Version:** `Apple clang version 15.0.0 (clang-1500.3.9.4)`

**SDK Version:** 17.5
