### PR TITLE
Update Fedora Install Script

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -354,7 +354,7 @@ linux() {
 				|| (error "Dependency install command seems to have encountered an error. Please see the log above."; exit 3)
 			;;
 		redhat)
-			sudo dnf group install -y "C Development Tools and Libraries" --refresh \
+			sudo dnf group install -y "c-development" --refresh \
 				&& update "Dependencies have been successfully installed!" \
 				|| (error "Dependency install command seems to have encountered an error. Please see the log above."; exit 3)
 			sudo dnf install -y fakeroot lzma libbsd rsync curl perl zip git libxml2 \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The current script does not work on Fedora 41, so I have changed it to do so. The issues lies in trying to install the group by the name rather than the id, which is the (current) functionality. (See more at https://dnf5.readthedocs.io/en/latest/changes_from_dnf4.7.html)

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
```bash
Failed to resolve the transaction:
No match for argument: Development Tools
You can try to add to command line:
  --skip-unavailable to skip unavailable packages
==> Dependency install command seems to have encountered an error. Please see the log above.
```

Any other comments?
-------------------
Nope!

Where has this been tested?
---------------------------
**Operating System:** Fedora 41

**Platform:** Framework Laptop 13 _AMD Ryzen 7040Series_

**Target Platform:** N/A

**Toolchain Version:** N/A

**SDK Version:** N/A
