### PR TITLE
Avoid rate limits of the GitHub APIs

### DIFF
--- a/bin/install-sdk
+++ b/bin/install-sdk
@@ -10,7 +10,12 @@
 
 set -e
 
-urls=$(curl -s https://api.github.com/repos/theos/sdks/releases/latest | grep download_url | sed 's/.*: "\(.*\)"/\1/')
+SDK_FETCH_URL="https://api.github.com/repos/theos/sdks/releases/latest"
+if [ ! -z "$GITHUB_TOKEN" ]; then
+	urls=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
+else
+	urls=$(curl -s $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
+fi
 if [[ -z "$urls" ]]; then
 	echo "ERROR: api.github.com request failed?!" >&2
 	exit 1

--- a/bin/install-sdk
+++ b/bin/install-sdk
@@ -11,7 +11,7 @@
 set -e
 
 SDK_FETCH_URL="https://api.github.com/repos/theos/sdks/releases/latest"
-if [ ! -z "$GITHUB_TOKEN" ]; then
+if ! [[ -z "$GITHUB_TOKEN" ]]; then
 	urls=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
 else
 	urls=$(curl -s $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request reduces occuring of `1 - api.github.com request failed` error.

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------
[Yes](https://github.com/OwnGoalStudio/SingleMute/actions/runs/11795027751/job/32853960143).

Any other comments?
-------------------
See [Make authenticated requests](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#make-authenticated-requests).

The unauthenticated primary rate limit of GitHub API is **60 requests per hour**. That's not enough when you're using shared CI runners or IP addresses with your roommate.

Where has this been tested?
---------------------------
**Operating System:** macOS 14.7.1 (23H222) / GitHub CI runner `macOS-14`

**Platform:** Any

**Target Platform:** Any

**Toolchain Version:** Any

**SDK Version:** Any
