### PR TITLE
Respect ZDOTDIR

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -59,9 +59,9 @@ elif [[ $CSHELL == zsh ]]; then
 	# Zsh prioritizes zshenv > zprofile > zshrc
         zdot="${ZDOTDIR:-$HOME}"
 	if [[ -f $zdot/.zshenv ]]; then
-		SHELL_ENV="$HOME/.zshenv"
+		SHELL_ENV="$zdot/.zshenv"
 	elif [[ -f $zdot/.zprofile ]]; then
-		SHELL_ENV="$HOME/.zprofile"
+		SHELL_ENV="$zdot/.zprofile"
 	else
 		SHELL_ENV="$zdot/.zshrc"
 	fi

--- a/bin/install-theos
+++ b/bin/install-theos
@@ -57,12 +57,13 @@ if [[ $CSHELL == sh || $CSHELL == bash || $CSHELL == dash ]]; then
 	fi
 elif [[ $CSHELL == zsh ]]; then
 	# Zsh prioritizes zshenv > zprofile > zshrc
-	if [[ -f $HOME/.zshenv ]]; then
+        zdot="${ZDOTDIR:-$HOME}"
+	if [[ -f $zdot/.zshenv ]]; then
 		SHELL_ENV="$HOME/.zshenv"
-	elif [[ -f $HOME/.zprofile ]]; then
+	elif [[ -f $zdot/.zprofile ]]; then
 		SHELL_ENV="$HOME/.zprofile"
 	else
-		SHELL_ENV="$HOME/.zshrc"
+		SHELL_ENV="$zdot/.zshrc"
 	fi
 # TODO
 # elif [[ $CSHELL == csh ]]; then


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
ZDOTDIR is the path to the user's zsh configuration, so it may not always be located in the home directory,
More information could be found in zsh man page,

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No
