### PR TITLE
Ask the user for a GitHub API token if the request fails in bin/install-sdk

### DIFF
--- a/bin/install-sdk
+++ b/bin/install-sdk
@@ -17,12 +17,12 @@ else
 	urls=$(curl -s $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
 fi
 if [[ -z "$urls" ]]; then
-	echo "GitHub API request failed. Please enter a GitHub API token to retry:" >&2
+	echo "GitHub API request failed. Please enter a GitHub API token to retry:"
         read token
         export GITHUB_TOKEN=$token
         urls=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
         if [[ -z "$urls" ]]; then
-          echo "ERROR: GitHub API request failed again."
+          echo "ERROR: GitHub API request failed again." >&2
           exit 1
         fi
 fi

--- a/bin/install-sdk
+++ b/bin/install-sdk
@@ -17,8 +17,14 @@ else
 	urls=$(curl -s $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
 fi
 if [[ -z "$urls" ]]; then
-	echo "ERROR: api.github.com request failed?!" >&2
-	exit 1
+	echo "GitHub API request failed. Please enter a GitHub API token to retry:" >&2
+        read token
+        export GITHUB_TOKEN=$token
+        urls=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
+        if [[ -z "$urls" ]]; then
+          echo "ERROR: GitHub API request failed again."
+          exit 1
+        fi
 fi
 
 sdks=( $(echo "$urls" | sed -e 's/.*\///' -e 's/\.sdk.*//' | tr '\n' ' ') )

--- a/bin/install-sdk
+++ b/bin/install-sdk
@@ -19,8 +19,7 @@ fi
 if [[ -z "$urls" ]]; then
 	echo "GitHub API request failed. Please enter a GitHub API token to retry:"
         read token
-        export GITHUB_TOKEN=$token
-        urls=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
+        urls=$(curl -s -H "Authorization: Bearer $token" $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
         if [[ -z "$urls" ]]; then
           echo "ERROR: GitHub API request failed again." >&2
           exit 1

--- a/bin/install-sdk
+++ b/bin/install-sdk
@@ -17,9 +17,10 @@ else
 	urls=$(curl -s $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
 fi
 if [[ -z "$urls" ]]; then
-	echo "GitHub API request failed. Please enter a GitHub API token to retry:"
-        read token
-        urls=$(curl -s -H "Authorization: Bearer $token" $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
+	echo "GitHub API request failed. Please set the GITHUB_TOKEN environment variable and try again."
+        echo "Dropping you to a shell, type exit when done."
+        bash
+        urls=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" $SDK_FETCH_URL | grep download_url | sed 's/.*: "\(.*\)"/\1/')
         if [[ -z "$urls" ]]; then
           echo "ERROR: GitHub API request failed again." >&2
           exit 1


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
I've fixed the issue when I install Theos, and the installation goes to installing SDKs, this happens:

```
==> Checking for patched SDKs...

==> SDKs do not appear to be installed. Installing now...
ERROR: api.github.com request failed?!
==> Something appears to have gone wrong. Please try again.
```

Now the installer will ask the user for a token if the GitHub API request fails.

Any relevant logs, error output, etc?
-------------------------------------
<details>
<summary>Theos install command output (most long parts omitted)</summary>

```
==> Theos Installer: Starting install...

==> Platform: Linux

==> Preparing to install dependencies. Please enter your password if prompted:

==> Dependencies have been successfully installed!

==> Checking for WSL...

==> Seems you're not using WSL. Moving on...

==> Checking for $THEOS environment variable...

==> $THEOS is already set to '/home/pr0gramm3r101/theos'. Nothing to do here.

==> Checking for Theos install...

==> Theos does not appear to be installed. Cloning now...

==> Git clone of Theos was successful!

==> Checking for iOS toolchain...

==> A toolchain does not appear to be installed.
Would you like your toolchain to support Swift (larger toolchain size) or not (smaller toolchain size)? [y/n]n

==> Successfully installed the toolchain!

==> Checking for patched SDKs...

==> SDKs do not appear to be installed. Installing now...
ERROR: api.github.com request failed?!
==> Something appears to have gone wrong. Please try again.
```
</details>

Where has this been tested?
---------------------------
**Operating System:** Linux, macOS

**Target Platform:** iOS 15

**Toolchain Version:** latest

**SDK Version:** latest
