### PR TITLE
Implement library weak linking according to the docs

### DIFF
--- a/makefiles/instance/rules.mk
+++ b/makefiles/instance/rules.mk
@@ -118,8 +118,8 @@ _THEOS_INTERNAL_LDFLAGS += $(foreach framework,$($(_THEOS_CURRENT_TYPE)_WEAK_FRA
 _THEOS_INTERNAL_LDFLAGS += $(foreach framework,$(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,WEAK_FRAMEWORKS),-weak_framework $(framework))
 
 # Add weak libraries.
-_THEOS_INTERNAL_LDFLAGS += $(foreach library,$($(_THEOS_CURRENT_TYPE)_WEAK_LIBRARIES),-weak_library $(library))
-_THEOS_INTERNAL_LDFLAGS += $(foreach library,$(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,WEAK_LIBRARIES),-weak_library $(library))
+_THEOS_INTERNAL_LDFLAGS += $(foreach library,$($(_THEOS_CURRENT_TYPE)_WEAK_LIBRARIES),-weak-l$(library))
+_THEOS_INTERNAL_LDFLAGS += $(foreach library,$(call __schema_var_all,$(THEOS_CURRENT_INSTANCE)_,WEAK_LIBRARIES),-weak-l$(library))
 
 # Static libraries do not support having multiple arm64e ABIs, we need to manually choose the correct ABI
 IS_NEW_ABI := $(call __vercmp,$(_THEOS_TARGET_CC_VERSION),ge,12.0.0)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes `XXX_WEAK_LIBRARIES` using `-weak_library` instead of `-weak-l`

Does this close any currently open issues?
------------------------------------------
#841

Where has this been tested?
---------------------------
**Operating System:** macOS 13.7.5

**Platform:** …

**Target Platform:** …

**Toolchain Version:** Xcode 15.2

**SDK Version:** 14.4
