### PR TITLE
Adjust `plutil` prioritization to account for faulty Linux variant 

### DIFF
--- a/bin/convert_xml_plist.sh
+++ b/bin/convert_xml_plist.sh
@@ -21,7 +21,7 @@ fi
 
 # Check for plist converters
 # A Linux package(s) appear to offer a non-Darwin plutil - we want to avoid it 
-if [[ "$(uname -s)" == "Darwin" ]] && command -v plutil &> /dev/null; then
+if [[ "$(uname)" == "Darwin" ]] && command -v plutil &> /dev/null; then
     cmd=plutil
 elif command -v plistutil &> /dev/null; then
     cmd=plistutil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
No longer prioritizes `plutil` for all platforms 

Does this close any currently open issues?
------------------------------------------
Closes #779 


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
