### PR TITLE
Update `install-theos` Linux distro determination logic

### DIFF
--- a/bin/install-theos
+++ b/bin/install-theos
@@ -322,15 +322,24 @@ darwin_mobile() {
 
 linux() {
 	# Determine distro
+	source /etc/os-release 
 	DISTRO="unknown"
-	if [[ -x $(command -v apt) ]]; then
-		DISTRO="debian"
-	elif [[ -x $(command -v pacman) ]]; then
-		DISTRO="arch"
-	elif [[ -x $(command -v dnf) ]]; then
-		DISTRO="redhat"
-	elif [[ -x $(command -v zypper) ]]; then
-		DISTRO="suse"
+	# First pass for namesake distros 
+	case "$ID" in
+	    debian) DISTRO="debian" ;;
+	    arch) DISTRO="arch" ;;
+	    rhel|fedora) DISTRO="redhat" ;;
+	    suse) DISTRO="suse" ;;
+	esac
+
+	# Second pass for derivatives
+	if [[ "$DISTRO" == "unknown" ]]; then
+	    case "$ID_LIKE" in
+	        *debian*) DISTRO="debian" ;;
+	        *arch*) DISTRO="arch" ;;
+	        *rhel*|*fedora*) DISTRO="redhat" ;;
+	        *suse*) DISTRO="suse" ;;
+	    esac
 	fi
 
 	# Check for sudo (not installed by default on some distros)

--- a/bin/install-theos
+++ b/bin/install-theos
@@ -324,6 +324,7 @@ linux() {
 	# Determine distro
 	source /etc/os-release 
 	DISTRO="unknown"
+	
 	# First pass for namesake distros 
 	case "$ID" in
 	    debian) DISTRO="debian" ;;
@@ -338,6 +339,21 @@ linux() {
 	        *debian*) DISTRO="debian" ;;
 	        *arch*) DISTRO="arch" ;;
 	        *rhel*|*fedora*) DISTRO="redhat" ;;
+	        *suse*) DISTRO="suse" ;;
+	    esac
+	fi
+
+	# Third pass for legacy
+	if [[ "$DISTRO" == "unknown" ]]; then
+		# parse for /etc/*-release file(s)
+		rel=(/etc/*-release)
+		rel=(${rel[@]#/etc/})
+		rel=(${rel[@]%-release})
+
+		case "${rel[@]}" in
+	        *debian*) DISTRO="debian" ;;
+	        *arch*) DISTRO="arch" ;;
+	        *redhat*|*fedora*) DISTRO="redhat" ;;
 	        *suse*) DISTRO="suse" ;;
 	    esac
 	fi

--- a/bin/install-theos
+++ b/bin/install-theos
@@ -349,16 +349,14 @@ linux() {
 
 	# Third pass for legacy
 	if [[ "$DISTRO" == "unknown" ]]; then
-		# parse for /etc/*-release file(s)
 		rel_files=(/etc/*release /etc/*version)
-		rel=$(cat "${rel_files[@]}" 2>/dev/null | tr '[:upper:]' '[:lower:]')
-
-		case "$rel" in
-	        *debian*) DISTRO="debian" ;;
-	        *arch*) DISTRO="arch" ;;
-	        *redhat*|*fedora*) DISTRO="redhat" ;;
-	        *suse*) DISTRO="suse" ;;
-	    esac
+		for rel in "${rel_files[@]}"; do
+			case "${rel,,}" in
+				*debian*) DISTRO="debian" ;;
+				*arch*)   DISTRO="arch" ;;
+				*redhat*|*fedora*) DISTRO="redhat" ;;
+			esac
+		done
 	fi
 
 	# Check for sudo (not installed by default on some distros)

--- a/bin/install-theos
+++ b/bin/install-theos
@@ -295,7 +295,7 @@ darwin_mobile() {
 				exit 3
 			fi
 		fi
-		
+
 		# Check desire for Swift support
 		update "Checking desire for Swift support..."
 		read -p "Would you like to be able to work with Swift? If so, an additional package will need to be installed. [y/n]" confirm
@@ -322,15 +322,15 @@ darwin_mobile() {
 
 linux() {
 	# Determine distro
-	source /etc/os-release 
+	source /etc/os-release
 	DISTRO="unknown"
-	
-	# First pass for namesake distros 
+
+	# First pass for namesake distros
 	case "$ID" in
 	    debian) DISTRO="debian" ;;
 	    arch) DISTRO="arch" ;;
 	    rhel|fedora) DISTRO="redhat" ;;
-	    suse) DISTRO="suse" ;;
+	    *suse*) DISTRO="suse" ;;
 	esac
 
 	# Second pass for derivatives
@@ -346,11 +346,10 @@ linux() {
 	# Third pass for legacy
 	if [[ "$DISTRO" == "unknown" ]]; then
 		# parse for /etc/*-release file(s)
-		rel=(/etc/*-release)
-		rel=(${rel[@]#/etc/})
-		rel=(${rel[@]%-release})
+		rel_files=(/etc/*release /etc/*version)
+		rel=$(cat "${rel_files[@]}" 2>/dev/null | tr '[:upper:]' '[:lower:]')
 
-		case "${rel[@]}" in
+		case "$rel" in
 	        *debian*) DISTRO="debian" ;;
 	        *arch*) DISTRO="arch" ;;
 	        *redhat*|*fedora*) DISTRO="redhat" ;;

--- a/bin/install-theos
+++ b/bin/install-theos
@@ -322,7 +322,11 @@ darwin_mobile() {
 
 linux() {
 	# Determine distro
-	source /etc/os-release
+	if [ -e /etc/os-release ]; then
+		source /etc/os-release
+	elif [ -e /usr/lib/os-release ]; then
+		source /usr/lib/os-release
+	fi
 	DISTRO="unknown"
 
 	# First pass for namesake distros


### PR DESCRIPTION
Relying now on os-release instead of package manager, which can be muddied by user installs

<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Previously relied on the package manager to determine the Linux flavor. Now relying on ID and ID_LIKE fields in os-release as more robust 

Does this close any currently open issues?
------------------------------------------
Resolves #832 


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
