### PR TITLE
Fix hanging on fakeroot on Linux/Docker

### DIFF
--- a/bin/fakeroot.sh
+++ b/bin/fakeroot.sh
@@ -26,7 +26,7 @@ if [[ $delpersistence -eq 1 ]]; then
 	exit 0
 fi
 
-if [[ "$USER" == "root" || "$(id -u)" -eq 0  ]]; then
+if [[ "$USER" == "root" || "$EUID" -eq 0 ]]; then
 	fakeroot=""
 elif type fauxsu &> /dev/null; then
 	fakeroot="fauxsu -p $persistence -- "


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
While working on a project of mine that automates building of Theos projects, I ran into an issue where Theos would hang on fakeroot inside Docker containers as it would incorrectly identify root users, only judging them by their username instead of their ID. This PR makes a very small edit to the fakeroot.sh script that seems to have fixed everything at least in my testing!

Does this close any currently open issues?
------------------------------------------
No.

Any other comments?
-------------------
Nothing other than a thank you for maintaining this awesome project :)

Where has this been tested?
---------------------------
**Operating System:** Debian 12 (`python:3.12-slim` Docker image)