### PR TITLE
Fix `install-sdk` usage on legacy OSX

### DIFF
--- a/bin/install-sdk
+++ b/bin/install-sdk
@@ -29,7 +29,7 @@ if [[ $# -ne 1 ]]; then
 	exit 2
 fi
 
-if ! printf '%s\0' "${sdks[@]}" | grep -F -x -z -- "${1}"; then
+if ! printf '%s\n' "${sdks[@]}" | grep -F -x -- "$1" >/dev/null; then
 	echo "ERROR: we do not currently provide $1.sdk!" >&2
 	exit 3
 fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Replaces newer `grep -z` usage with portable version 

Does this close any currently open issues?
------------------------------------------
Closes #873 


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

Debian 14 - WSL

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
