### PR TITLE
Adjust `offline-docs.yml` final copy to accommodate adjusted assets paths

### DIFF
--- a/.github/workflows/offline-docs.yml
+++ b/.github/workflows/offline-docs.yml
@@ -30,9 +30,8 @@ jobs:
       - name: Build docs
         run: |
           make -C tmp all
-          mkdir -pv docs/assets/
-          cp -av tmp/_site/docs/* docs/
-          cp -av tmp/_site/assets/*.css tmp/_site/assets/*.svg docs/assets/
+          cp -av tmp/_site/docs/ .
+          cp -av tmp/_site/assets docs/
           rm -rvf tmp
 
       - name: Cleanup broken formatting

--- a/.github/workflows/offline-docs.yml
+++ b/.github/workflows/offline-docs.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Build docs
         run: |
+          rm -rvf docs/
           make -C tmp all
           cp -av tmp/_site/docs/ .
           cp -av tmp/_site/assets docs/


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Title

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
I believe this is the last of it as the paths are already made relative via `sed` ... 3rd time's the charm!

> cp: cannot stat 'tmp/_site/assets/*.css': No such file or directory
> cp: cannot stat 'tmp/_site/assets/*.svg': No such file or directory

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
