### PR TITLE
Handle fakeroot(-tcp|-sysv) in `fakeroot.sh` instead of `install-theos`

### DIFF
--- a/bin/fakeroot.sh
+++ b/bin/fakeroot.sh
@@ -2,6 +2,12 @@
 required=0
 persistence=/tmp/dhbxxx
 
+is_wsl1() {
+    rel="$1"
+	rel_lc=$(printf '%s' "$rel" | tr '[:upper:]' '[:lower:]')
+    [[ $rel_lc =~ microsoft && ! $rel =~ WSL2 ]]
+}
+
 while getopts ":p:rc" flag; do
 	case "$flag" in
 		:)	echo "$0: Option -$OPTARG requires an argument." 1>&2
@@ -33,7 +39,16 @@ elif type fauxsu &> /dev/null; then
 elif type fakeroot-ng &> /dev/null; then
 	fakeroot="fakeroot-ng -p $persistence -- "
 elif type fakeroot &> /dev/null; then
-	fakeroot="fakeroot -i $persistence -s $persistence -- "
+	# favor fakeroot backend with greatest support
+	# (circumvents harsher tcp restrictions on some distros (e.g., Fedora 41))
+	if type fakeroot-sysv &> /dev/null && ! is_wsl1 "$(uname -r)"; then
+		fakeroot="fakeroot-sysv -i $persistence -s $persistence -- "
+	# no -sysv on WSL1, so favor TCP
+	elif is_wsl1 "$(uname -r)"; then
+		fakeroot="fakeroot-tcp -i $persistence -s $persistence -- "
+	else
+		fakeroot="fakeroot -i $persistence -s $persistence -- "
+	fi
 else
 	if [[ $required -eq 1 ]]; then
 		fakeroot=""

--- a/bin/install-theos
+++ b/bin/install-theos
@@ -10,8 +10,7 @@
 # 7 - Toolchain install failed
 # 8 - SDK install failed
 # 9 - Checkra1n '/opt' setup failed
-# 10 - fakeroot adjustment failed
-# 11 - Enabling Linux binary compat on FreeBSD failed
+# 10 - Enabling Linux binary compat on FreeBSD failed
 
 set -e
 
@@ -295,7 +294,7 @@ darwin_mobile() {
 				exit 3
 			fi
 		fi
-		
+
 		# Check desire for Swift support
 		update "Checking desire for Swift support..."
 		read -p "Would you like to be able to work with Swift? If so, an additional package will need to be installed. [y/n]" confirm
@@ -377,28 +376,6 @@ linux() {
 			common "Additional dependencies may also be required depending on what your distro provides."
 			;;
 	esac
-
-	# favor fakeroot backend with greatest support (circumvents harsher tcp restrictions on some distros (e.g., Fedora 41))
-	update "Adjusting fakeroot to favor sysv > tcp..."
-	sudo update-alternatives --set fakeroot /usr/bin/fakeroot-sysv \
-		&& update "fakeroot adjusted!" \
-		|| (error "fakeroot adjustment seems to have encountered an error. Please see the log above."; exit 10)
-
-	# Check for WSL
-	update "Checking for WSL..."
-	rel="$(uname -r)"
-	if [[ ${rel,,} =~ microsoft ]]; then
-		if ! [[ $rel =~ WSL2 ]]; then
-			update "WSL1! Need to adjust fakeroot as no sysv..."
-			sudo update-alternatives --set fakeroot /usr/bin/fakeroot-tcp \
-				&& update "fakeroot adjusted!" \
-				|| (error "fakeroot adjustment seems to have encountered an error. Please see the log above."; exit 10)
-		else
-			update "WSL2! Nothing to do here."
-		fi
-	else
-		update "Seems you're not using WSL. Moving on..."
-	fi
 
 	set_theos
 	get_theos
@@ -499,7 +476,7 @@ linux() {
 # 	sudo service linux start
 # 	sudo pkg install -y linux_base-c7 \
 # 		&& update "Linux binary compatibility successfully enabled!" \
-# 		|| (error "Linux binary compatibility command seems to have encountered an error. Please see the log above."; exit 11)
+# 		|| (error "Linux binary compatibility command seems to have encountered an error. Please see the log above."; exit 10)
 
 # 	# Compatibility with common Theos commands
 # 	# TODO: Should we be doing this?


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Stops modifying user alternatives during install (thanks Cookie and legit in #theos-general for caring about this and bringing it to my attention!)

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
- Fixes install on contemporary Arch distros 
- **Untested** on relevant platforms 

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
